### PR TITLE
Feat/freeboard 스크롤 기능 구현

### DIFF
--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -25,6 +25,6 @@ public class FreeBoardController {
 
     @GetMapping("/scroll")
     public FreeBoardScrollResponse scrollBoard(@ModelAttribute FreeBoardScrollRequest request) {
-        return freeBoardService.findBoardByScroll(request);
+        return freeBoardService.findBoardScroll(request);
     }
 }

--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -25,6 +25,6 @@ public class FreeBoardController {
 
     @GetMapping("/scroll")
     public FreeBoardScrollResponse scrollBoard(@ModelAttribute FreeBoardScrollRequest request) {
-        return freeBoardService.findBoardScroll(request);
+        return freeBoardService.findScroll(request);
     }
 }

--- a/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
@@ -5,12 +5,15 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sideeffect.project.domain.user.User;
 
 @Entity
 @Getter
@@ -39,7 +42,10 @@ public class FreeBoard {
 
     private String imgUrl;
 
-    private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Builder
     public FreeBoard(Long id, String title, String projectUrl, String content, String imgUrl, Long userId) {
@@ -49,7 +55,6 @@ public class FreeBoard {
         this.projectUrl = projectUrl;
         this.content = content;
         this.imgUrl = imgUrl;
-        this.userId = userId;
     }
 
     public void update(FreeBoard freeBoard) {
@@ -76,7 +81,11 @@ public class FreeBoard {
         this.imgUrl = null;
     }
 
-    public void setUser(Long userId) {
-        this.userId = userId;
+    public void associateUser(User user) {
+        if (this.user != null) {
+            this.user.deleteFreeBoard(this);
+        }
+        user.addFreeBoard(this);
+        this.user = user;
     }
 }

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -1,9 +1,12 @@
 package sideeffect.project.domain.user;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import sideeffect.project.domain.freeboard.FreeBoard;
 
 @Entity
 @Getter @Setter
@@ -16,16 +19,23 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
+
     @Column(name = "user_name")
     private String name;
+
     private String password;
+
     private String nickname;
+
     private String email;
+
     @Enumerated(EnumType.STRING)
     private UserRoleType userRoleType;
 
     private LocalDateTime createAt;
+
     private LocalDateTime updateAt;
+
     private LocalDateTime deleteAt;
 
     @Enumerated(EnumType.STRING)
@@ -33,4 +43,16 @@ public class User {
 
     private String imgUrl;
 
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+    @OrderBy("id desc")
+    private List<FreeBoard> freeBoards = new ArrayList<>();
+
+    public void addFreeBoard(FreeBoard freeBoard) {
+        this.freeBoards.add(freeBoard);
+    }
+
+    public void deleteFreeBoard(FreeBoard freeBoard) {
+        this.freeBoards.remove(freeBoard);
+    }
 }

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardKeyWordRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardKeyWordRequest.java
@@ -1,0 +1,23 @@
+package sideeffect.project.dto.freeboard;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FreeBoardKeyWordRequest {
+    private Long lastId;
+
+    @NotNull
+    private int size;
+
+    @NotEmpty
+    private String keyWord;
+}

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
@@ -34,7 +34,7 @@ public class FreeBoardResponse {
             .id(freeBoard.getId())
             .views(freeBoard.getViews())
             .title(freeBoard.getTitle())
-            .userId(freeBoard.getUserId())
+            .userId(freeBoard.getUser().getId())
             .content(freeBoard.getContent())
             .projectUrl(freeBoard.getProjectUrl())
             .imgUrl(freeBoard.getImgUrl())

--- a/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
@@ -4,11 +4,19 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sideeffect.project.domain.freeboard.FreeBoard;
 
 public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long> {
 
-    List<FreeBoard> findAllByContentContainingOrTitleContaining(String content, String title);
+    @Query("SELECT b from FreeBoard b where b.content like %:keyword% or b.title like %:keyword% "
+    + "order by b.id desc")
+    List<FreeBoard> findFreeBoardWithKeyWord(@Param("keyword") String keyWord, Pageable pageable);
+
+    @Query("SELECT b from FreeBoard b where b.id < :id and (b.content like %:keyword% or b.title like %:keyword%) "
+        + "order by b.id desc")
+    List<FreeBoard> findFreeBoardScrollWithKeyWord(@Param("keyword") String keyWord, @Param("id") Long id,
+        Pageable pageable);
 
     @Query("SELECT b from FreeBoard b order by b.id desc")
     List<FreeBoard> findLastPagingBoards(Pageable pageable);

--- a/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
@@ -11,15 +11,15 @@ public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long> {
 
     @Query("SELECT b from FreeBoard b where b.content like %:keyword% or b.title like %:keyword% "
     + "order by b.id desc")
-    List<FreeBoard> findFreeBoardWithKeyWord(@Param("keyword") String keyWord, Pageable pageable);
+    List<FreeBoard> findStartScrollOfBoardsWithKeyWord(@Param("keyword") String keyWord, Pageable pageable);
 
     @Query("SELECT b from FreeBoard b where b.id < :id and (b.content like %:keyword% or b.title like %:keyword%) "
         + "order by b.id desc")
-    List<FreeBoard> findFreeBoardScrollWithKeyWord(@Param("keyword") String keyWord, @Param("id") Long id,
+    List<FreeBoard> findScrollOfBoardsWithKeyWord(@Param("keyword") String keyWord, @Param("id") Long id,
         Pageable pageable);
 
     @Query("SELECT b from FreeBoard b order by b.id desc")
-    List<FreeBoard> findLastPagingBoards(Pageable pageable);
+    List<FreeBoard> findStartScrollOfBoard(Pageable pageable);
 
     List<FreeBoard> findByIdLessThanOrderByIdDesc(Long boardId, Pageable pageable);
 }

--- a/server/src/main/java/sideeffect/project/repository/UserRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/UserRepository.java
@@ -1,5 +1,8 @@
 package sideeffect.project.repository;
 
-public class UserRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import sideeffect.project.domain.user.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
 
 }

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -27,7 +27,7 @@ public class FreeBoardService {
     }
 
     @Transactional(readOnly = true)
-    public FreeBoardScrollResponse findBoardByScroll(FreeBoardScrollRequest request) {
+    public FreeBoardScrollResponse findBoardScroll(FreeBoardScrollRequest request) {
         if (request.getLastId() == null) {
             List<FreeBoard> freeBoards = repository.findLastPagingBoards(Pageable.ofSize(request.getSize()));
             return FreeBoardScrollResponse

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
@@ -35,7 +36,23 @@ public class FreeBoardService {
         }
         List<FreeBoard> freeBoards = repository
             .findByIdLessThanOrderByIdDesc(request.getLastId(), Pageable.ofSize(request.getSize()));
-        return FreeBoardScrollResponse.of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+    }
+
+    @Transactional(readOnly = true)
+    public FreeBoardScrollResponse findBoardWithKeywordScroll(FreeBoardKeyWordRequest request) {
+        if (request.getLastId() == null) {
+            List<FreeBoard> freeBoards = repository.findFreeBoardWithKeyWord(request.getKeyWord(),
+                Pageable.ofSize(request.getSize()));
+            return FreeBoardScrollResponse
+                .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+        }
+        List<FreeBoard> freeBoards = repository
+            .findFreeBoardScrollWithKeyWord(request.getKeyWord(), request.getLastId(),
+                Pageable.ofSize(request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
     }
 
     @Transactional

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -32,31 +32,19 @@ public class FreeBoardService {
     }
 
     @Transactional(readOnly = true)
-    public FreeBoardScrollResponse findBoardScroll(FreeBoardScrollRequest request) {
+    public FreeBoardScrollResponse findScroll(FreeBoardScrollRequest request) {
         if (request.getLastId() == null) {
-            List<FreeBoard> freeBoards = repository.findLastPagingBoards(Pageable.ofSize(request.getSize()));
-            return FreeBoardScrollResponse
-                .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+            return findStartScrollOfBoards(request);
         }
-        List<FreeBoard> freeBoards = repository
-            .findByIdLessThanOrderByIdDesc(request.getLastId(), Pageable.ofSize(request.getSize()));
-        return FreeBoardScrollResponse
-            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+        return findBoards(request);
     }
 
     @Transactional(readOnly = true)
-    public FreeBoardScrollResponse findBoardWithKeywordScroll(FreeBoardKeyWordRequest request) {
+    public FreeBoardScrollResponse findScrollWithKeyword(FreeBoardKeyWordRequest request) {
         if (request.getLastId() == null) {
-            List<FreeBoard> freeBoards = repository.findFreeBoardWithKeyWord(request.getKeyWord(),
-                Pageable.ofSize(request.getSize()));
-            return FreeBoardScrollResponse
-                .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+            return findStartScrollBoardWithKeyword(request);
         }
-        List<FreeBoard> freeBoards = repository
-            .findFreeBoardScrollWithKeyWord(request.getKeyWord(), request.getLastId(),
-                Pageable.ofSize(request.getSize()));
-        return FreeBoardScrollResponse
-            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+        return findScrollBoardWithKeyword(request);
     }
 
     @Transactional
@@ -78,6 +66,34 @@ public class FreeBoardService {
         FreeBoard freeBoard = repository.findById(boardId).orElseThrow(EntityNotFoundException::new);
         validateOwner(userId, freeBoard);
         repository.delete(freeBoard);
+    }
+
+    private FreeBoardScrollResponse findBoards(FreeBoardScrollRequest request) {
+        List<FreeBoard> freeBoards = repository
+            .findByIdLessThanOrderByIdDesc(request.getLastId(), Pageable.ofSize(request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+    }
+
+    private FreeBoardScrollResponse findStartScrollOfBoards(FreeBoardScrollRequest request) {
+        List<FreeBoard> freeBoards = repository.findStartScrollOfBoard(Pageable.ofSize(request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+    }
+
+    private FreeBoardScrollResponse findScrollBoardWithKeyword(FreeBoardKeyWordRequest request) {
+        List<FreeBoard> freeBoards = repository
+            .findScrollOfBoardsWithKeyWord(request.getKeyWord(), request.getLastId(),
+                Pageable.ofSize(request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
+    }
+
+    private FreeBoardScrollResponse findStartScrollBoardWithKeyword(FreeBoardKeyWordRequest request) {
+        List<FreeBoard> freeBoards = repository
+            .findStartScrollOfBoardsWithKeyWord(request.getKeyWord(), Pageable.ofSize(request.getSize()));
+        return FreeBoardScrollResponse
+            .of(FreeBoardResponse.listOf(freeBoards), hasNextBoards(freeBoards, request.getSize()));
     }
 
     private void validateOwner(Long userId, FreeBoard freeBoard) {

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -7,23 +7,27 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.user.User;
 import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
 import sideeffect.project.repository.FreeBoardRepository;
+import sideeffect.project.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class FreeBoardService {
 
     private final FreeBoardRepository repository;
+    private final UserRepository userRepository;
 
     @Transactional
     public FreeBoard register(Long userId, FreeBoardRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         FreeBoard freeBoard = request.toFreeBoard();
-        freeBoard.setUser(userId);
+        freeBoard.associateUser(user);
         return repository.save(freeBoard);
     }
 
@@ -77,7 +81,7 @@ public class FreeBoardService {
     }
 
     private void validateOwner(Long userId, FreeBoard freeBoard) {
-        if (!userId.equals(freeBoard.getUserId())) {
+        if (!userId.equals(freeBoard.getUser().getId())) {
             throw new IllegalArgumentException("게시글의 주인이 아닙니다.");
         }
     }

--- a/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.user.User;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
 import sideeffect.project.service.FreeBoardService;
@@ -32,20 +33,28 @@ class FreeBoardControllerTest {
     private MockMvc mvc;
 
     private FreeBoardResponse response;
+    private FreeBoard freeBoard;
+    private User user;
 
     @BeforeEach
     void setUp(WebApplicationContext context) {
         mvc = MockMvcBuilders.webAppContextSetup(context)
             .build();
 
-        FreeBoard freeBoard = FreeBoard.builder()
+        user = User.builder()
+            .id(1L)
+            .name("test")
+            .password("1234")
+            .build();
+
+        freeBoard = FreeBoard.builder()
             .id(1L)
             .title("게시판입니다.")
-            .userId(1L)
             .projectUrl("url")
             .imgUrl("/test.jpg")
             .content("test")
             .build();
+        freeBoard.associateUser(user);
         response = FreeBoardResponse.of(freeBoard);
     }
 
@@ -71,6 +80,8 @@ class FreeBoardControllerTest {
     void scrollBoard() throws Exception {
         FreeBoard board1 = FreeBoard.builder().id(100L).userId(1L).content("게시판1입니다.").title("게시판1").build();
         FreeBoard board2 = FreeBoard.builder().id(99L).userId(1L).content("게시판2입니다.").title("게시판2").build();
+        board1.associateUser(user);
+        board2.associateUser(user);
         List<FreeBoardResponse> responses = FreeBoardResponse.listOf(List.of(board1, board2));
         FreeBoardScrollResponse scrollResponse = FreeBoardScrollResponse.of(responses, false);
         when(freeBoardService.findBoardScroll(any())).thenReturn(scrollResponse);

--- a/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
@@ -84,7 +84,7 @@ class FreeBoardControllerTest {
         board2.associateUser(user);
         List<FreeBoardResponse> responses = FreeBoardResponse.listOf(List.of(board1, board2));
         FreeBoardScrollResponse scrollResponse = FreeBoardScrollResponse.of(responses, false);
-        when(freeBoardService.findBoardScroll(any())).thenReturn(scrollResponse);
+        when(freeBoardService.findScroll(any())).thenReturn(scrollResponse);
 
         mvc.perform(get("/api/free-board/scroll")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
@@ -73,7 +73,7 @@ class FreeBoardControllerTest {
         FreeBoard board2 = FreeBoard.builder().id(99L).userId(1L).content("게시판2입니다.").title("게시판2").build();
         List<FreeBoardResponse> responses = FreeBoardResponse.listOf(List.of(board1, board2));
         FreeBoardScrollResponse scrollResponse = FreeBoardScrollResponse.of(responses, false);
-        when(freeBoardService.findBoardByScroll(any())).thenReturn(scrollResponse);
+        when(freeBoardService.findBoardScroll(any())).thenReturn(scrollResponse);
 
         mvc.perform(get("/api/free-board/scroll")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/sideeffect/project/domain/freeboard/FreeBoardTest.java
+++ b/server/src/test/java/sideeffect/project/domain/freeboard/FreeBoardTest.java
@@ -10,10 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
 
 class FreeBoardTest {
 
     private FreeBoard freeBoard;
+    private User user;
 
     @BeforeEach
     void setUp() {
@@ -23,6 +26,15 @@ class FreeBoardTest {
             .imgUrl("/test.jpg")
             .projectUrl("http://test.url")
             .content("게시판 입니다.")
+            .build();
+
+        user = User.builder()
+            .id(1L)
+            .name("hello")
+            .nickname("tester")
+            .password("1234")
+            .userRoleType(UserRoleType.ROLE_USER)
+            .email("test@naver.com")
             .build();
     }
 
@@ -80,13 +92,34 @@ class FreeBoardTest {
 
     @DisplayName("유저를 설정한다.")
     @Test
-    void setUser() {
-        Long userId = 1L;
+    void associateUser() {
+        freeBoard.associateUser(user);
 
-        freeBoard.setUser(userId);
-
-        assertThat(freeBoard.getUserId()).isEqualTo(userId);
+        assertAll(
+            () -> assertThat(freeBoard.getUser()).isEqualTo(user),
+            () -> assertThat(user.getFreeBoards()).contains(freeBoard)
+        );
     }
+
+    @DisplayName("유저를 재설정 한다.")
+    @Test
+    void updateUser() {
+        User newUser = User.builder()
+            .id(2L)
+            .name("new")
+            .password("1234")
+            .nickname("newUser")
+            .build();
+        freeBoard.associateUser(user);
+        freeBoard.associateUser(newUser);
+
+        assertAll(
+            () -> assertThat(freeBoard.getUser()).isEqualTo(newUser),
+            () -> assertThat(newUser.getFreeBoards()).contains(freeBoard),
+            () -> assertThat(user.getFreeBoards()).doesNotContain(freeBoard)
+        );
+    }
+
 
     private static Stream<Arguments> generateUpdateBoards() {
         return Stream.of(

--- a/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
@@ -45,7 +45,7 @@ class FreeBoardRepositoryTest {
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
-        List<FreeBoard> boards = repository.findAllByContentContainingOrTitleContaining(content, null);
+        List<FreeBoard> boards = repository.findFreeBoardWithKeyWord(content, Pageable.ofSize(5));
 
         assertThat(boards).containsExactly(freeBoard);
     }
@@ -58,7 +58,7 @@ class FreeBoardRepositoryTest {
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
-        List<FreeBoard> boards = repository.findAllByContentContainingOrTitleContaining(null, title);
+        List<FreeBoard> boards = repository.findFreeBoardWithKeyWord(title, Pageable.ofSize(5));
 
         assertThat(boards).containsExactly(freeBoard);
     }
@@ -98,6 +98,23 @@ class FreeBoardRepositoryTest {
             () -> assertThat(freeBoards).hasSize(10),
             () -> assertThat(resultBoardId).isEqualTo(answerBoardIds)
         );
+    }
+
+    @DisplayName("검색 결과를 페이징 방식으로 조회")
+    @Test
+    void findFreeBoardScrollWithKeyWord() {
+        String title = "검색할 제목";
+        FreeBoard freeBoard1 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        FreeBoard freeBoard2 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        FreeBoard freeBoard3 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        repository.save(freeBoard1);
+        repository.save(freeBoard2);
+        repository.save(freeBoard3);
+
+        List<FreeBoard> boards = repository
+            .findFreeBoardScrollWithKeyWord(title, freeBoard2.getId() + 1, Pageable.ofSize(5));
+
+        assertThat(boards).containsExactly(freeBoard2, freeBoard1);
     }
 
     private Long getLastId() {

--- a/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
@@ -45,7 +45,7 @@ class FreeBoardRepositoryTest {
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
-        List<FreeBoard> boards = repository.findFreeBoardWithKeyWord(content, Pageable.ofSize(5));
+        List<FreeBoard> boards = repository.findStartScrollOfBoardsWithKeyWord(content, Pageable.ofSize(5));
 
         assertThat(boards).containsExactly(freeBoard);
     }
@@ -58,7 +58,7 @@ class FreeBoardRepositoryTest {
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
-        List<FreeBoard> boards = repository.findFreeBoardWithKeyWord(title, Pageable.ofSize(5));
+        List<FreeBoard> boards = repository.findStartScrollOfBoardsWithKeyWord(title, Pageable.ofSize(5));
 
         assertThat(boards).containsExactly(freeBoard);
     }
@@ -73,7 +73,7 @@ class FreeBoardRepositoryTest {
         Collections.reverse(answerBoardIds);
 
         List<FreeBoard> freeBoards = repository
-            .findLastPagingBoards(Pageable.ofSize(pagingSize));
+            .findStartScrollOfBoard(Pageable.ofSize(pagingSize));
         List<Long> resultBoardId = freeBoards.stream().map(FreeBoard::getId).collect(Collectors.toList());
 
         assertAll(
@@ -112,7 +112,7 @@ class FreeBoardRepositoryTest {
         repository.save(freeBoard3);
 
         List<FreeBoard> boards = repository
-            .findFreeBoardScrollWithKeyWord(title, freeBoard2.getId() + 1, Pageable.ofSize(5));
+            .findScrollOfBoardsWithKeyWord(title, freeBoard2.getId() + 1, Pageable.ofSize(5));
 
         assertThat(boards).containsExactly(freeBoard2, freeBoard1);
     }

--- a/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
@@ -132,7 +132,7 @@ class FreeBoardServiceTest {
     void findBoardByScroll(FreeBoardScrollRequest request, List<FreeBoard> freeBoards, boolean hasNext) {
         when(freeBoardRepository.findByIdLessThanOrderByIdDesc(any(), any())).thenReturn(freeBoards);
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardByScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findBoardScroll(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(freeBoards.get(freeBoards.size() - 1).getId()),
@@ -147,7 +147,7 @@ class FreeBoardServiceTest {
     void findBoardByScrollWithoutLastId(FreeBoardScrollRequest request, List<FreeBoard> freeBoards, boolean hasNext) {
         when(freeBoardRepository.findLastPagingBoards(any())).thenReturn(freeBoards);
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardByScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findBoardScroll(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(freeBoards.get(freeBoards.size() - 1).getId()),

--- a/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
@@ -152,7 +152,7 @@ class FreeBoardServiceTest {
     void findBoardByScroll(FreeBoardScrollRequest request, List<FreeBoard> freeBoards, boolean hasNext) {
         when(freeBoardRepository.findByIdLessThanOrderByIdDesc(any(), any())).thenReturn(freeBoards);
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findScroll(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(freeBoards.get(freeBoards.size() - 1).getId()),
@@ -165,14 +165,14 @@ class FreeBoardServiceTest {
     @MethodSource("generateScrollTestWithoutLastIdAugments")
     @ParameterizedTest
     void findBoardByScrollWithoutLastId(FreeBoardScrollRequest request, List<FreeBoard> freeBoards, boolean hasNext) {
-        when(freeBoardRepository.findLastPagingBoards(any())).thenReturn(freeBoards);
+        when(freeBoardRepository.findStartScrollOfBoard(any())).thenReturn(freeBoards);
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findScroll(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(freeBoards.get(freeBoards.size() - 1).getId()),
             () -> assertThat(response.isHasNext()).isEqualTo(hasNext),
-            () -> verify(freeBoardRepository).findLastPagingBoards(any())
+            () -> verify(freeBoardRepository).findStartScrollOfBoard(any())
         );
     }
 
@@ -184,14 +184,14 @@ class FreeBoardServiceTest {
         freeBoard1.associateUser(user);
         freeBoard2.associateUser(user);
         FreeBoardKeyWordRequest request = FreeBoardKeyWordRequest.builder().keyWord("test").size(2).build();
-        when(freeBoardRepository.findFreeBoardWithKeyWord(any(), any())).thenReturn(List.of(freeBoard1, freeBoard2));
+        when(freeBoardRepository.findStartScrollOfBoardsWithKeyWord(any(), any())).thenReturn(List.of(freeBoard1, freeBoard2));
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardWithKeywordScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findScrollWithKeyword(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(90L),
             () -> assertThat(response.isHasNext()).isTrue(),
-            () -> verify(freeBoardRepository).findFreeBoardWithKeyWord(any(), any())
+            () -> verify(freeBoardRepository).findStartScrollOfBoardsWithKeyWord(any(), any())
         );
     }
 
@@ -204,15 +204,15 @@ class FreeBoardServiceTest {
         freeBoard2.associateUser(user);
         FreeBoardKeyWordRequest request = FreeBoardKeyWordRequest
             .builder().lastId(100L).keyWord("test").size(5).build();
-        when(freeBoardRepository.findFreeBoardScrollWithKeyWord(any(), any(), any()))
+        when(freeBoardRepository.findScrollOfBoardsWithKeyWord(any(), any(), any()))
             .thenReturn(List.of(freeBoard1, freeBoard2));
 
-        FreeBoardScrollResponse response = freeBoardService.findBoardWithKeywordScroll(request);
+        FreeBoardScrollResponse response = freeBoardService.findScrollWithKeyword(request);
 
         assertAll(
             () -> assertThat(response.getLastId()).isEqualTo(90L),
             () -> assertThat(response.isHasNext()).isFalse(),
-            () -> verify(freeBoardRepository).findFreeBoardScrollWithKeyWord(any(), any(), any())
+            () -> verify(freeBoardRepository).findScrollOfBoardsWithKeyWord(any(), any(), any())
         );
     }
 

--- a/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
@@ -153,6 +154,42 @@ class FreeBoardServiceTest {
             () -> assertThat(response.getLastId()).isEqualTo(freeBoards.get(freeBoards.size() - 1).getId()),
             () -> assertThat(response.isHasNext()).isEqualTo(hasNext),
             () -> verify(freeBoardRepository).findLastPagingBoards(any())
+        );
+    }
+
+    @DisplayName("게시판 검색 시작 스크롤을 조회")
+    @Test
+    void findBoardWithKeywordScrollWithoutLastId() {
+        FreeBoard freeBoard1 = FreeBoard.builder().id(95L).content("test").title("게시판").build();
+        FreeBoard freeBoard2 = FreeBoard.builder().id(90L).content("게시판 입니다.").title("test").build();
+        FreeBoardKeyWordRequest request = FreeBoardKeyWordRequest.builder().keyWord("test").size(2).build();
+        when(freeBoardRepository.findFreeBoardWithKeyWord(any(), any())).thenReturn(List.of(freeBoard1, freeBoard2));
+
+        FreeBoardScrollResponse response = freeBoardService.findBoardWithKeywordScroll(request);
+
+        assertAll(
+            () -> assertThat(response.getLastId()).isEqualTo(90L),
+            () -> assertThat(response.isHasNext()).isTrue(),
+            () -> verify(freeBoardRepository).findFreeBoardWithKeyWord(any(), any())
+        );
+    }
+
+    @DisplayName("게시판 검색 스크롤 조회")
+    @Test
+    void findBoardWithKeywordScroll() {
+        FreeBoard freeBoard1 = FreeBoard.builder().id(95L).content("test").title("게시판").build();
+        FreeBoard freeBoard2 = FreeBoard.builder().id(90L).content("게시판 입니다.").title("test").build();
+        FreeBoardKeyWordRequest request = FreeBoardKeyWordRequest
+            .builder().lastId(100L).keyWord("test").size(5).build();
+        when(freeBoardRepository.findFreeBoardScrollWithKeyWord(any(), any(), any()))
+            .thenReturn(List.of(freeBoard1, freeBoard2));
+
+        FreeBoardScrollResponse response = freeBoardService.findBoardWithKeywordScroll(request);
+
+        assertAll(
+            () -> assertThat(response.getLastId()).isEqualTo(90L),
+            () -> assertThat(response.isHasNext()).isFalse(),
+            () -> verify(freeBoardRepository).findFreeBoardScrollWithKeyWord(any(), any(), any())
         );
     }
 


### PR DESCRIPTION
다음의 기능을 구현했습니다.
- 스크롤 기능과 검색( 제목과 내용에 키워드 매칭)
- 유저 엔티티와 연관관계 설정