### PR TITLE
Feat/recruit board 스크롤 및 검색 기능 구현

### DIFF
--- a/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
+++ b/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
@@ -7,7 +7,14 @@ public enum ErrorCode {
     FREE_BOARD_NOT_FOUND(400, "FB_001", "해당 게시판을 찾을 수 없습니다."),
 
     COMMENT_NOT_FOUND(400, "CM_001", "해당 댓글을 찾을 수 없습니다."),
-    COMMENT_UNAUTHORIZED(403, "CM_002", "해당 댓글에 대한 권한이 없습니다.");
+    COMMENT_UNAUTHORIZED(403, "CM_002", "해당 댓글에 대한 권한이 없습니다."),
+
+    RECRUIT_BOARD_NOT_FOUND(400, "RB_001", "해당 모집 게시판을 찾을 수 없습니다."),
+    RECRUIT_BOARD_UNAUTHORIZED(403, "RB_002", "해당 모집 게시판에 대한 권한이 없습니다."),
+
+    POSITION_NOT_FOUND(400, "PS_001", "해당 포지션을 찾을 수 없습니다."),
+
+    STACK_NOT_FOUND(400, "ST_001", "해당 기술스택을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
@@ -1,11 +1,10 @@
 package sideeffect.project.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sideeffect.project.dto.recruit.RecruitBoardResponse;
+import sideeffect.project.dto.recruit.RecruitBoardScrollRequest;
+import sideeffect.project.dto.recruit.RecruitBoardScrollResponse;
 import sideeffect.project.service.RecruitBoardService;
 
 @RestController
@@ -18,6 +17,11 @@ public class RecruitBoardController {
     @GetMapping("/{id}")
     public RecruitBoardResponse findRecruitBoard(@PathVariable Long id) {
         return recruitBoardService.findRecruitBoard(id);
+    }
+
+    @GetMapping("/scroll")
+    public RecruitBoardScrollResponse findScrollRecruitBoard(@ModelAttribute RecruitBoardScrollRequest request) {
+        return recruitBoardService.findRecruitBoards(request);
     }
 
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
@@ -42,7 +42,7 @@ public class BoardPosition {
         this.recruitBoard = recruitBoard;
     }
 
-    public void addRecruitBoard(RecruitBoard recruitBoard) {
+    public void setRecruitBoard(RecruitBoard recruitBoard) {
         this.recruitBoard = recruitBoard;
     }
 

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
@@ -41,4 +41,9 @@ public class BoardPosition {
         this.position = position;
         this.recruitBoard = recruitBoard;
     }
+
+    public void addRecruitBoard(RecruitBoard recruitBoard) {
+        this.recruitBoard = recruitBoard;
+    }
+
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardStack.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardStack.java
@@ -38,4 +38,9 @@ public class BoardStack {
         this.stack = stack;
         this.recruitBoard = recruitBoard;
     }
+
+    public void addRecruitBoard(RecruitBoard recruitBoard) {
+        this.recruitBoard = recruitBoard;
+    }
+
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardStack.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardStack.java
@@ -39,7 +39,7 @@ public class BoardStack {
         this.recruitBoard = recruitBoard;
     }
 
-    public void addRecruitBoard(RecruitBoard recruitBoard) {
+    public void setRecruitBoard(RecruitBoard recruitBoard) {
         this.recruitBoard = recruitBoard;
     }
 

--- a/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sideeffect.project.domain.user.User;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -40,7 +41,9 @@ public class RecruitBoard {
 
     private LocalDateTime deadline;
 
-    private Long userId;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @OneToMany(mappedBy = "recruitBoard", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<BoardPosition> boardPositions = new ArrayList<>();
@@ -49,7 +52,7 @@ public class RecruitBoard {
     private List<BoardStack> boardStacks = new ArrayList<>();
 
     @Builder
-    public RecruitBoard(Long id, String title, String contents, RecruitBoardType recruitBoardType, ProgressType progressType, String expectedPeriod, LocalDateTime deadline, Long userId) {
+    public RecruitBoard(Long id, String title, String contents, RecruitBoardType recruitBoardType, ProgressType progressType, String expectedPeriod, LocalDateTime deadline) {
         this.id = id;
         this.title = title;
         this.contents = contents;
@@ -58,7 +61,6 @@ public class RecruitBoard {
         this.progressType = progressType;
         this.expectedPeriod = expectedPeriod;
         this.deadline = deadline;
-        this.userId = userId;
     }
 
     public void updateBoardPositions(List<BoardPosition> boardPositions) {
@@ -104,8 +106,12 @@ public class RecruitBoard {
         this.views++;
     }
 
-    public void setUser(Long userId) {
-        this.userId = userId;
+    public void associateUser(User user) {
+        if (this.user != null) {
+            this.user.deleteRecruitBoard(this);
+        }
+        user.addRecruitBoard(this);
+        this.user = user;
     }
 
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sideeffect.project.common.domain.BaseTimeEntity;
 import sideeffect.project.domain.user.User;
 
 import javax.persistence.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @Table(name = "RECRUIT_BOARD")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RecruitBoard {
+public class RecruitBoard extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -75,10 +76,12 @@ public class RecruitBoard {
 
     public void addBoardPosition(BoardPosition boardPosition) {
         this.boardPositions.add(boardPosition);
+        boardPosition.addRecruitBoard(this);
     }
 
     public void addBoardStack(BoardStack boardStack) {
         this.boardStacks.add(boardStack);
+        boardStack.addRecruitBoard(this);
     }
 
     public void update(RecruitBoard recruitBoard) {

--- a/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
@@ -76,12 +76,12 @@ public class RecruitBoard extends BaseTimeEntity {
 
     public void addBoardPosition(BoardPosition boardPosition) {
         this.boardPositions.add(boardPosition);
-        boardPosition.addRecruitBoard(this);
+        boardPosition.setRecruitBoard(this);
     }
 
     public void addBoardStack(BoardStack boardStack) {
         this.boardStacks.add(boardStack);
-        boardStack.addRecruitBoard(this);
+        boardStack.setRecruitBoard(this);
     }
 
     public void update(RecruitBoard recruitBoard) {

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -1,12 +1,13 @@
 package sideeffect.project.domain.user;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.*;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.recruit.RecruitBoard;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import sideeffect.project.domain.freeboard.FreeBoard;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter @Setter
@@ -48,11 +49,24 @@ public class User {
     @OrderBy("id desc")
     private List<FreeBoard> freeBoards = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+    @OrderBy("id desc")
+    private List<RecruitBoard> recruitBoards = new ArrayList<>();
+
     public void addFreeBoard(FreeBoard freeBoard) {
         this.freeBoards.add(freeBoard);
     }
 
     public void deleteFreeBoard(FreeBoard freeBoard) {
         this.freeBoards.remove(freeBoard);
+    }
+
+    public void addRecruitBoard(RecruitBoard recruitBoard) {
+        this.recruitBoards.add(recruitBoard);
+    }
+
+    public void deleteRecruitBoard(RecruitBoard recruitBoard) {
+        this.recruitBoards.remove(recruitBoard);
     }
 }

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
@@ -7,6 +7,7 @@ import sideeffect.project.domain.recruit.RecruitBoardType;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -38,6 +39,12 @@ public class RecruitBoardResponse {
                 .positions(BoardPositionResponse.listOf(recruitBoard.getBoardPositions()))
                 .stacks(BoardStackResponse.listOf(recruitBoard.getBoardStacks()))
                 .build();
+    }
+
+    public static List<RecruitBoardResponse> listOf(List<RecruitBoard> recruitBoards) {
+        return recruitBoards.stream()
+                .map(RecruitBoardResponse::of)
+                .collect(Collectors.toList());
     }
 
 }

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardScrollRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardScrollRequest.java
@@ -1,0 +1,21 @@
+package sideeffect.project.dto.recruit;
+
+import lombok.*;
+import sideeffect.project.domain.stack.StackType;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class RecruitBoardScrollRequest {
+
+    private Long lastId;
+    @NotNull
+    private int size;
+    private String keyword;
+    private List<StackType> stackTypes;
+
+}

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardScrollResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardScrollResponse.java
@@ -1,0 +1,25 @@
+package sideeffect.project.dto.recruit;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class RecruitBoardScrollResponse {
+
+    private List<RecruitBoardResponse> recruitBoards;
+    private Long lastId;
+    private boolean hasNext;
+
+    public static RecruitBoardScrollResponse of(List<RecruitBoardResponse> recruitBoards, boolean hasNext) {
+        return RecruitBoardScrollResponse.builder()
+                .recruitBoards(recruitBoards)
+                .lastId(recruitBoards.get(recruitBoards.size() - 1).getId())
+                .hasNext(hasNext)
+                .build();
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
@@ -1,0 +1,11 @@
+package sideeffect.project.repository;
+
+import org.springframework.data.domain.Pageable;
+import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.domain.stack.StackType;
+
+import java.util.List;
+
+public interface RecruitBoardCustomRepository {
+    List<RecruitBoard> findWithSearchConditions(Long lastId, String keyword, List<StackType> stackTypes, Pageable pageable);
+}

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
@@ -1,0 +1,69 @@
+package sideeffect.project.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.StringUtils;
+import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.domain.stack.StackType;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RecruitBoardCustomRepositoryImpl implements RecruitBoardCustomRepository{
+
+    private final EntityManager em;
+
+    @Override
+    public List<RecruitBoard> findWithSearchConditions(Long lastId, String keyword, List<StackType> stackTypes, Pageable pageable) {
+
+        String jpql = "select distinct rb from RecruitBoard rb";
+        String joinSql = "";
+        String whereSql = " where ";
+        List<String> whereConditions = new ArrayList<>();
+
+        if(lastId != null) {
+            whereConditions.add("rb.id < :lastId");
+        }
+
+        if(stackTypes != null && !stackTypes.isEmpty()) {
+            joinSql += " join rb.boardStacks bs";
+            whereConditions.add("bs.stack.stackType in :stackTypes");
+        }
+
+        if(StringUtils.hasText(keyword)) {
+            whereConditions.add("(rb.title like concat('%',:keyword,'%') or rb.contents like concat('%',:keyword,'%'))");
+        }
+
+        if(StringUtils.hasText(joinSql)) {
+            jpql += joinSql;
+        }
+
+        if(!whereConditions.isEmpty()) {
+            jpql += whereSql;
+            jpql += String.join(" and ", whereConditions);
+        }
+
+        jpql += " order by rb.id desc";
+
+        TypedQuery<RecruitBoard> query = em.createQuery(jpql, RecruitBoard.class);
+
+        if(lastId != null) {
+            query.setParameter("lastId", lastId);
+        }
+
+        if(stackTypes != null && !stackTypes.isEmpty()) {
+            query.setParameter("stackTypes", stackTypes);
+        }
+
+        if(StringUtils.hasText(keyword)) {
+            query.setParameter("keyword", keyword);
+        }
+
+        return query.setMaxResults(pageable.getPageSize()).getResultList();
+    }
+}

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
@@ -3,5 +3,5 @@ package sideeffect.project.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sideeffect.project.domain.recruit.RecruitBoard;
 
-public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long> {
+public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long>, RecruitBoardCustomRepository {
 }

--- a/server/src/main/java/sideeffect/project/service/PositionService.java
+++ b/server/src/main/java/sideeffect/project/service/PositionService.java
@@ -3,11 +3,11 @@ package sideeffect.project.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.position.PositionType;
 import sideeffect.project.repository.PositionRepository;
-
-import javax.persistence.EntityNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +17,8 @@ public class PositionService {
 
     @Transactional(readOnly = true)
     public Position findByPositionType(PositionType positionType) {
-        return positionRepository.findByPositionType(positionType).orElseThrow(EntityNotFoundException::new);
+        return positionRepository.findByPositionType(positionType)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POSITION_NOT_FOUND));
     }
 
 }

--- a/server/src/main/java/sideeffect/project/service/StackService.java
+++ b/server/src/main/java/sideeffect/project/service/StackService.java
@@ -3,11 +3,11 @@ package sideeffect.project.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
 import sideeffect.project.domain.stack.Stack;
 import sideeffect.project.domain.stack.StackType;
 import sideeffect.project.repository.StackRepository;
-
-import javax.persistence.EntityNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +17,8 @@ public class StackService {
 
     @Transactional(readOnly = true)
     public Stack findByStackType(StackType stackType) {
-        return stackRepository.findByStackType(stackType).orElseThrow(EntityNotFoundException::new);
+        return stackRepository.findByStackType(stackType)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STACK_NOT_FOUND));
     }
 
 }

--- a/server/src/test/java/sideeffect/project/domain/recruit/RecruitBoardTest.java
+++ b/server/src/test/java/sideeffect/project/domain/recruit/RecruitBoardTest.java
@@ -27,7 +27,6 @@ class RecruitBoardTest {
     void setUp() {
         user = User.builder()
                 .id(1L)
-                .name("testName")
                 .nickname("test")
                 .password("1234")
                 .userRoleType(UserRoleType.ROLE_USER)

--- a/server/src/test/java/sideeffect/project/domain/recruit/RecruitBoardTest.java
+++ b/server/src/test/java/sideeffect/project/domain/recruit/RecruitBoardTest.java
@@ -1,0 +1,150 @@
+package sideeffect.project.domain.recruit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import sideeffect.project.domain.stack.StackLevelType;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class RecruitBoardTest {
+
+    private User user;
+    private RecruitBoard recruitBoard;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .name("testName")
+                .nickname("test")
+                .password("1234")
+                .userRoleType(UserRoleType.ROLE_USER)
+                .email("test@naver.com")
+                .build();
+
+        recruitBoard = RecruitBoard.builder()
+                .id(1L)
+                .title("모집 게시판")
+                .contents("모집합니다.")
+                .recruitBoardType(RecruitBoardType.PROJECT)
+                .progressType(ProgressType.ONLINE)
+                .deadline(LocalDateTime.now())
+                .expectedPeriod("3개월")
+                .build();
+    }
+
+    @DisplayName("게시판의 포지션을 변경한다.")
+    @Test
+    void updateBoardPositions() {
+        List<BoardPosition> boardPositions = new ArrayList<>();
+
+        for(int i = 0; i < 3; i++) {
+            boardPositions.add(BoardPosition.builder()
+                    .targetNumber(3)
+                    .build());
+        }
+
+        recruitBoard.updateBoardPositions(boardPositions);
+
+        assertThat(recruitBoard.getBoardPositions()).hasSize(3);
+    }
+
+    @DisplayName("게시판의 스택을 변경한다.")
+    @Test
+    void updateBoardStacks() {
+        List<BoardStack> boardStacks = new ArrayList<>();
+
+        for(int i = 0; i < 3; i++) {
+            boardStacks.add(BoardStack.builder()
+                    .stackLevelType(StackLevelType.LOW)
+                    .build());
+        }
+
+        recruitBoard.updateBoardStacks(boardStacks);
+
+        assertThat(recruitBoard.getBoardStacks()).hasSize(3);
+    }
+
+    @DisplayName("모집 게시판을 업데이트 한다.")
+    @MethodSource("generateUpdateBoards")
+    @ParameterizedTest
+    void update(RecruitBoard updateRecruitBoard) {
+        recruitBoard.update(updateRecruitBoard);
+
+        assertAll(
+                () -> {
+                    if (updateRecruitBoard.getTitle() != null) {
+                        assertThat(recruitBoard.getTitle()).isEqualTo(updateRecruitBoard.getTitle());
+                    }
+                },
+                () -> {
+                    if (updateRecruitBoard.getContents() != null) {
+                        assertThat(recruitBoard.getContents()).isEqualTo(updateRecruitBoard.getContents());
+                    }
+                },
+                () -> {
+                    if (updateRecruitBoard.getRecruitBoardType() != null) {
+                        assertThat(recruitBoard.getRecruitBoardType()).isEqualTo(updateRecruitBoard.getRecruitBoardType());
+                    }
+                },
+                () -> {
+                    if (updateRecruitBoard.getProgressType() != null) {
+                        assertThat(recruitBoard.getProgressType()).isEqualTo(updateRecruitBoard.getProgressType());
+                    }
+                },
+                () -> {
+                    if (updateRecruitBoard.getDeadline() != null) {
+                        assertThat(recruitBoard.getDeadline()).isEqualTo(updateRecruitBoard.getDeadline());
+                    }
+                },
+                () -> {
+                    if (updateRecruitBoard.getExpectedPeriod() != null) {
+                        assertThat(recruitBoard.getExpectedPeriod()).isEqualTo(updateRecruitBoard.getExpectedPeriod());
+                    }
+                });
+    }
+
+    @DisplayName("게시판 조회수가 증가한다.")
+    @Test
+    void increaseViews() {
+        int beforeViews = recruitBoard.getViews();
+
+        recruitBoard.increaseViews();
+
+        assertThat(recruitBoard.getViews()).isEqualTo(beforeViews + 1);
+    }
+
+    @DisplayName("게시판의 유저를 설정한다.")
+    @Test
+    void associateUser() {
+        recruitBoard.associateUser(user);
+
+        assertAll(
+                () -> assertThat(recruitBoard.getUser()).isEqualTo(user),
+                () -> assertThat(user.getRecruitBoards()).contains(recruitBoard)
+        );
+    }
+
+    private static Stream<Arguments> generateUpdateBoards() {
+        return Stream.of(
+                Arguments.arguments(RecruitBoard.builder().title("변경").build()),
+                Arguments.arguments(RecruitBoard.builder().title("변경").contents("내용 변경").build()),
+                Arguments.arguments(RecruitBoard.builder().title("변경").contents("내용 변경").recruitBoardType(RecruitBoardType.STUDY).build()),
+                Arguments.arguments(RecruitBoard.builder().title("변경").contents("내용 변경").recruitBoardType(RecruitBoardType.STUDY).progressType(ProgressType.OFFLINE).build()),
+                Arguments.arguments(RecruitBoard.builder().title("변경").contents("내용 변경").recruitBoardType(RecruitBoardType.STUDY).progressType(ProgressType.OFFLINE).deadline(LocalDateTime.now().plusMinutes(5)).build()),
+                Arguments.arguments(RecruitBoard.builder().title("변경").contents("내용 변경").recruitBoardType(RecruitBoardType.STUDY).progressType(ProgressType.OFFLINE).deadline(LocalDateTime.now().plusMinutes(5)).expectedPeriod("1개월").build()));
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
@@ -1,0 +1,200 @@
+package sideeffect.project.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Pageable;
+import sideeffect.project.domain.position.Position;
+import sideeffect.project.domain.position.PositionType;
+import sideeffect.project.domain.recruit.*;
+import sideeffect.project.domain.stack.Stack;
+import sideeffect.project.domain.stack.StackType;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+class RecruitBoardRepositoryTest {
+
+    @Autowired
+    RecruitBoardRepository recruitBoardRepository;
+
+    @Autowired
+    PositionRepository positionRepository;
+
+    @Autowired
+    StackRepository stackRepository;
+
+    @Autowired
+    EntityManager em;
+
+    private Position frontEndPosition;
+    private Position backEndPosition;
+    private Stack javascriptStack;
+    private Stack javaStack;
+
+    @BeforeEach
+    void setUp() {
+        frontEndPosition = Position.builder().positionType(PositionType.FRONTEND).build();
+        backEndPosition = Position.builder().positionType(PositionType.BACKEND).build();
+        positionRepository.save(frontEndPosition);
+        positionRepository.save(backEndPosition);
+        javascriptStack = Stack.builder().stackType(StackType.JAVASCRIPT).build();
+        javaStack = Stack.builder().stackType(StackType.JAVA).build();
+        stackRepository.save(javascriptStack);
+        stackRepository.save(javaStack);
+
+        List<RecruitBoard> recruitBoards = new ArrayList<>();
+
+        for(int i = 1; i <= 40; i++) {
+            RecruitBoard recruitBoard = RecruitBoard.builder()
+                    .title("모집 게시판")
+                    .contents("내용입니다.")
+                    .recruitBoardType(RecruitBoardType.PROJECT)
+                    .progressType(ProgressType.ONLINE)
+                    .deadline(LocalDateTime.now())
+                    .expectedPeriod("3개월")
+                    .build();
+
+            recruitBoards.add(recruitBoard);
+        }
+
+        recruitBoardRepository.saveAll(recruitBoards);
+        em.clear();
+    }
+
+    @DisplayName("게시판 스크롤 페이징 조회")
+    @Test
+    void findRecruitBoardPaging() {
+        Long lastId = getLastId();
+        List<Long> answerBoardIds = LongStream.rangeClosed(lastId - 29, lastId - 20).sorted().boxed().collect(Collectors.toList());
+        Collections.reverse(answerBoardIds);
+
+        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(lastId - 19, "", null, Pageable.ofSize(10));
+        List<Long> returnBoardIds = findRecruitBoards.stream().map(RecruitBoard::getId).collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(findRecruitBoards).hasSize(10),
+                () -> assertThat(returnBoardIds).isEqualTo(answerBoardIds)
+        );
+    }
+
+    @DisplayName("게시판 키워드로 제목 검색")
+    @Test
+    void findRecruitBoardByTitle() {
+        String searchTitle = "검색할 제목";
+        RecruitBoard recruitBoardInSearchTitle = RecruitBoard.builder().title("모집 게시판" + searchTitle).contents("내용").build();
+        RecruitBoard recruitBoardNotInSearchTitle = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        recruitBoardRepository.save(recruitBoardInSearchTitle);
+        recruitBoardRepository.save(recruitBoardNotInSearchTitle);
+
+        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchTitle, null, Pageable.ofSize(5));
+
+        assertAll(
+                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInSearchTitle),
+                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInSearchTitle)
+        );
+    }
+
+    @DisplayName("게시판 키워드로 내용 검색")
+    @Test
+    void findRecruitBoardByContents() {
+        String searchContents = "검색할 컨텐츠";
+        RecruitBoard recruitBoardInSearchContents = RecruitBoard.builder().title("모집 게시판").contents("!@#$%" + searchContents).build();
+        RecruitBoard recruitBoardNotInSearchContents = RecruitBoard.builder().title("모집 게시판").contents("!@#$%").build();
+        recruitBoardRepository.save(recruitBoardInSearchContents);
+        recruitBoardRepository.save(recruitBoardNotInSearchContents);
+
+        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchContents, null, Pageable.ofSize(5));
+
+        assertAll(
+                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInSearchContents),
+                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInSearchContents)
+        );
+    }
+
+    @DisplayName("게시판 기술스택으로 검색")
+    @Test
+    void findRecruitBoardByStacks() {
+        BoardStack boardJavaStack = BoardStack.builder().stack(javaStack).build();
+        RecruitBoard recruitBoardInJavaStack = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        recruitBoardInJavaStack.addBoardStack(boardJavaStack);
+
+        BoardStack boardJavaInScriptStack = BoardStack.builder().stack(javascriptStack).build();
+        RecruitBoard recruitBoardInJavaScriptStack = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        recruitBoardInJavaScriptStack.addBoardStack(boardJavaInScriptStack);
+
+        RecruitBoard recruitBoardNotInStack = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+
+        recruitBoardRepository.save(recruitBoardInJavaStack);
+        recruitBoardRepository.save(recruitBoardInJavaScriptStack);
+        recruitBoardRepository.save(recruitBoardNotInStack);
+
+        List<StackType> searchStacks = new ArrayList<>();
+        searchStacks.add(StackType.JAVA);
+        searchStacks.add(StackType.JAVASCRIPT);
+
+        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, "", searchStacks, Pageable.ofSize(5));
+
+        assertAll(
+                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInJavaScriptStack, recruitBoardInJavaStack),
+                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInStack)
+        );
+    }
+
+    @DisplayName("게시판 키워드와 기술스택으로 검색")
+    @Test
+    void findRecruitBoardByKeywordWithStacks() {
+        String searchKeyword = "검색할 키워드";
+        BoardStack boardStackJava1 = BoardStack.builder().stack(javaStack).build();
+        RecruitBoard boardInKeywordWithStacks = RecruitBoard.builder().title("모집 게시판" + searchKeyword).contents("내용").build();
+        boardInKeywordWithStacks.addBoardStack(boardStackJava1);
+
+        BoardStack boardStackJavaScript = BoardStack.builder().stack(javascriptStack).build();
+        RecruitBoard boardInKeywordWithOtherStacks = RecruitBoard.builder().title("모집 게시판" + searchKeyword).contents("내용").build();
+        boardInKeywordWithStacks.addBoardStack(boardStackJavaScript);
+
+        RecruitBoard boardInKeyword = RecruitBoard.builder().title("모집 게시판" + searchKeyword).contents("내용").build();
+        BoardStack boardStackJava2 = BoardStack.builder().stack(javaStack).build();
+
+        RecruitBoard boardInStacks = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        boardInStacks.addBoardStack(boardStackJava2);
+
+        RecruitBoard boardNotInKeywordWithStacks = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+
+        recruitBoardRepository.save(boardInKeywordWithStacks);
+        recruitBoardRepository.save(boardInKeywordWithOtherStacks);
+        recruitBoardRepository.save(boardInKeyword);
+        recruitBoardRepository.save(boardInStacks);
+        recruitBoardRepository.save(boardNotInKeywordWithStacks);
+
+        List<StackType> searchStacks = new ArrayList<>();
+        searchStacks.add(StackType.JAVA);
+
+        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchKeyword, searchStacks, Pageable.ofSize(5));
+
+        assertAll(
+                () -> assertThat(findRecruitBoards).containsExactly(boardInKeywordWithStacks),
+                () -> assertThat(findRecruitBoards).doesNotContain(boardInKeywordWithOtherStacks),
+                () -> assertThat(findRecruitBoards).doesNotContain(boardInKeyword),
+                () -> assertThat(findRecruitBoards).doesNotContain(boardInStacks),
+                () -> assertThat(findRecruitBoards).doesNotContain(boardNotInKeywordWithStacks)
+        );
+    }
+
+    private Long getLastId() {
+        List<RecruitBoard> recruitBoards = recruitBoardRepository.findAll();
+        return recruitBoards.get(recruitBoards.size() - 1).getId();
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -59,7 +59,6 @@ class RecruitBoardServiceTest {
     void setUp() {
         user = User.builder()
                 .id(1L)
-                .name("testName")
                 .nickname("test")
                 .password("1234")
                 .userRoleType(UserRoleType.ROLE_USER)

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sideeffect.project.common.exception.AuthException;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.position.PositionType;
 import sideeffect.project.domain.recruit.ProgressType;
@@ -192,7 +193,7 @@ class RecruitBoardServiceTest {
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
 
         assertThatThrownBy(() -> recruitBoardService.updateRecruitBoard(nonOwnerId, boardId, request))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(AuthException.class);
     }
 
     @DisplayName("모집 게시판을 삭제한다.")
@@ -214,7 +215,7 @@ class RecruitBoardServiceTest {
         Long boardId = 1L;
 
         assertThatThrownBy(() -> recruitBoardService.deleteRecruitBoard(nonOwnerId, boardId))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(AuthException.class);
     }
 
     @DisplayName("모집 게시판 목록을 스크롤 조회한다.")

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,15 +20,15 @@ import sideeffect.project.domain.stack.StackLevelType;
 import sideeffect.project.domain.stack.StackType;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
-import sideeffect.project.dto.recruit.BoardPositionRequest;
-import sideeffect.project.dto.recruit.BoardStackRequest;
-import sideeffect.project.dto.recruit.RecruitBoardRequest;
+import sideeffect.project.dto.recruit.*;
 import sideeffect.project.repository.RecruitBoardRepository;
 import sideeffect.project.repository.UserRepository;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -214,4 +217,70 @@ class RecruitBoardServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("모집 게시판 목록을 스크롤 조회한다.")
+    @MethodSource("generateScrollTestAugments")
+    @ParameterizedTest
+    void findBoardsWithLastId(RecruitBoardScrollRequest request, List<RecruitBoard> recruitBoards, boolean hasNext) {
+        when(recruitBoardRepository.findWithSearchConditions(any(), any(), any(), any())).thenReturn(recruitBoards);
+
+        RecruitBoardScrollResponse scrollResponse = recruitBoardService.findRecruitBoards(request);
+
+        assertAll(
+                () -> verify(recruitBoardRepository).findWithSearchConditions(any(), any(), any(), any()),
+                () -> assertThat(scrollResponse.getLastId()).isEqualTo(recruitBoards.get(recruitBoards.size() - 1).getId()),
+                () -> assertThat(scrollResponse.isHasNext()).isEqualTo(hasNext)
+        );
+    }
+
+    @DisplayName("모집 게시판 목록을 키워드로 검색한다.")
+    @Test
+    void findBoardWithKeyword() {
+        String searchContents = "검색할 컨텐츠";
+        RecruitBoard recruitBoard1 = RecruitBoard.builder().id(10L).title("모집 게시판" + searchContents).contents("!@#$%").build();
+        RecruitBoard recruitBoard2 = RecruitBoard.builder().id(1L).title("모집 게시판").contents("!@#$%" + searchContents).build();
+        recruitBoard1.associateUser(user);
+        recruitBoard2.associateUser(user);
+        RecruitBoardScrollRequest request = RecruitBoardScrollRequest.builder().keyword(searchContents).size(2).build();
+
+        when(recruitBoardRepository.findWithSearchConditions(any(), any(), any(), any())).thenReturn(List.of(recruitBoard1, recruitBoard2));
+
+        RecruitBoardScrollResponse scrollResponse = recruitBoardService.findRecruitBoards(request);
+
+        assertAll(
+                () -> verify(recruitBoardRepository).findWithSearchConditions(any(), any(), any(), any()),
+                () -> assertThat(scrollResponse.getLastId()).isEqualTo(1L),
+                () -> assertThat(scrollResponse.isHasNext()).isFalse()
+        );
+
+    }
+
+    private static Stream<Arguments> generateScrollTestAugments() {
+        return Stream.of(
+                Arguments.arguments(RecruitBoardScrollRequest.builder().lastId(100L).size(10).build(),
+                        generateRecruitBoards(1L, 11), true),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().lastId(100L).size(11).build(),
+                        generateRecruitBoards(1L, 11), false),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().lastId(5L).size(1).build(),
+                        generateRecruitBoards(1L, 10), true),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().lastId(1L).size(10).build(),
+                        generateRecruitBoards(1L, 10), false),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().size(10).build(),
+                        generateRecruitBoards(1L, 11), true),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().size(10).build(),
+                        generateRecruitBoards(1L, 10), false),
+                Arguments.arguments(RecruitBoardScrollRequest.builder().size(1).build(),
+                        generateRecruitBoards(1L, 10), true)
+        );
+    }
+
+    private static List<RecruitBoard> generateRecruitBoards(Long startId, int size) {
+        User owner = User.builder().id(1L).email("test1234@naver.com").password("qwer1234!").build();
+        List<RecruitBoard> recruitBoards = new ArrayList<>();
+        for (Long i = startId; i < startId + size; i++) {
+            RecruitBoard recruitBoard = RecruitBoard.builder().id(i).title("모집 게시판" + i).contents("모집합니다." + i).build();
+            recruitBoard.associateUser(owner);
+            recruitBoards.add(recruitBoard);
+        }
+        return recruitBoards;
+    }
 }

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -15,10 +15,13 @@ import sideeffect.project.domain.recruit.RecruitBoardType;
 import sideeffect.project.domain.stack.Stack;
 import sideeffect.project.domain.stack.StackLevelType;
 import sideeffect.project.domain.stack.StackType;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
 import sideeffect.project.dto.recruit.BoardPositionRequest;
 import sideeffect.project.dto.recruit.BoardStackRequest;
 import sideeffect.project.dto.recruit.RecruitBoardRequest;
 import sideeffect.project.repository.RecruitBoardRepository;
+import sideeffect.project.repository.UserRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,20 +42,32 @@ class RecruitBoardServiceTest {
     private RecruitBoardRepository recruitBoardRepository;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private PositionService positionService;
 
     @Mock
     private StackService stackService;
 
+    private User user;
     private RecruitBoard recruitBoard;
     private Position position;
     private Stack stack;
 
     @BeforeEach
     void setUp() {
+        user = User.builder()
+                .id(1L)
+                .name("testName")
+                .nickname("test")
+                .password("1234")
+                .userRoleType(UserRoleType.ROLE_USER)
+                .email("test@naver.com")
+                .build();
+
         recruitBoard = RecruitBoard.builder()
                 .id(1L)
-                .userId(1L)
                 .title("모집 게시판")
                 .contents("모집합니다.")
                 .recruitBoardType(RecruitBoardType.PROJECT)
@@ -60,6 +75,8 @@ class RecruitBoardServiceTest {
                 .deadline(LocalDateTime.now())
                 .expectedPeriod("3개월")
                 .build();
+
+        recruitBoard.associateUser(user);
 
         position = Position.builder()
                 .id(1L)
@@ -89,6 +106,7 @@ class RecruitBoardServiceTest {
         Long userId = 1L;
 
         when(recruitBoardRepository.save(any())).thenReturn(recruitBoard);
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(positionService.findByPositionType(any())).thenReturn(position);
         when(stackService.findByStackType(any())).thenReturn(stack);
 


### PR DESCRIPTION
다음의 기능을 구현했습니다.

- 모집 게시판 스크롤 기능 구현
- 모집 게시판 검색 기능 구현 (제목과 내용 키워드 매칭)
- 모집 게시판 기술 스택 필터 기능 구현 (기술스택 OR방식 필터 기능)
- 유저 엔티티와 모집 게시판 연관관계 설정
- Service 예외를 사용자 예외로 변경