### PR TITLE
Feat/recommend 추천 기능 구현

### DIFF
--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -1,18 +1,20 @@
 package sideeffect.project.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
 import sideeffect.project.service.FreeBoardService;
 
 @RestController
-@RequestMapping("/api/free-board")
+@RequestMapping("/api/free-boards")
 @RequiredArgsConstructor
 public class FreeBoardController {
 
@@ -26,5 +28,15 @@ public class FreeBoardController {
     @GetMapping("/scroll")
     public FreeBoardScrollResponse scrollBoard(@ModelAttribute FreeBoardScrollRequest request) {
         return freeBoardService.findScroll(request);
+    }
+
+    @GetMapping("/search")
+    public FreeBoardScrollResponse searchBoard(@ModelAttribute FreeBoardKeyWordRequest request) {
+        return freeBoardService.findScrollWithKeyword(request);
+    }
+
+    @GetMapping("/rank")
+    public List<FreeBoardResponse> getRankBoard() {
+        return freeBoardService.findRankFreeBoards();
     }
 }

--- a/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sideeffect.project.common.domain.BaseTimeEntity;
 import sideeffect.project.domain.comment.Comment;
+import sideeffect.project.domain.recommend.Recommend;
 import sideeffect.project.domain.user.User;
 
 @Entity
@@ -51,13 +52,15 @@ public class FreeBoard extends BaseTimeEntity {
 
     private String imgUrl;
 
-
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard")
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard")
+    private List<Recommend> recommends = new ArrayList<>();
 
     @Builder
     public FreeBoard(Long id, String title, String projectUrl, String content, String imgUrl) {
@@ -68,6 +71,7 @@ public class FreeBoard extends BaseTimeEntity {
         this.content = content;
         this.imgUrl = imgUrl;
         this.comments = new ArrayList<>();
+        this.recommends = new ArrayList<>();
     }
 
     public void update(FreeBoard freeBoard) {
@@ -108,5 +112,13 @@ public class FreeBoard extends BaseTimeEntity {
 
     public void deleteComment(Comment comment) {
         this.comments.remove(comment);
+    }
+
+    public void addRecommend(Recommend recommend) {
+        this.recommends.add(recommend);
+    }
+
+    public void deleteRecommend(Recommend recommend) {
+        this.recommends.remove(recommend);
     }
 }

--- a/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
@@ -1,7 +1,9 @@
 package sideeffect.project.domain.freeboard;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -58,11 +60,11 @@ public class FreeBoard extends BaseTimeEntity {
     private User user;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard")
-    private List<Comment> comments = new ArrayList<>();
+    private List<Comment> comments;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard", orphanRemoval = true,
         cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private List<Recommend> recommends = new ArrayList<>();
+    private Set<Recommend> recommends;
 
     @Builder
     public FreeBoard(Long id, String title, String projectUrl, String content, String imgUrl) {
@@ -73,7 +75,7 @@ public class FreeBoard extends BaseTimeEntity {
         this.content = content;
         this.imgUrl = imgUrl;
         this.comments = new ArrayList<>();
-        this.recommends = new ArrayList<>();
+        this.recommends = new HashSet<>();
     }
 
     public void update(FreeBoard freeBoard) {

--- a/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/freeboard/FreeBoard.java
@@ -2,6 +2,7 @@ package sideeffect.project.domain.freeboard;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -59,7 +60,8 @@ public class FreeBoard extends BaseTimeEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard")
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "freeBoard", orphanRemoval = true,
+        cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<Recommend> recommends = new ArrayList<>();
 
     @Builder

--- a/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
+++ b/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
@@ -5,8 +5,10 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +19,11 @@ import sideeffect.project.domain.user.User;
 
 @Getter
 @Entity
+@Table(
+    indexes = {
+        @Index(name = "board_index", columnList = "free_board_id")
+    }
+)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recommend extends BaseTimeEntity {

--- a/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
+++ b/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
@@ -1,0 +1,35 @@
+package sideeffect.project.domain.recommend;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sideeffect.project.common.domain.BaseTimeEntity;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.user.User;
+
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recommend extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "free_board_id")
+    private FreeBoard freeBoard;
+}

--- a/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
+++ b/server/src/main/java/sideeffect/project/domain/recommend/Recommend.java
@@ -32,4 +32,21 @@ public class Recommend extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "free_board_id")
     private FreeBoard freeBoard;
+
+    public static Recommend recommend(User user, FreeBoard freeBoard) {
+        Recommend recommend = new Recommend();
+        recommend.setUser(user);
+        recommend.setFreeBoard(freeBoard);
+        return recommend;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        user.addRecommend(this);
+    }
+
+    public void setFreeBoard(FreeBoard freeBoard) {
+        this.freeBoard = freeBoard;
+        freeBoard.addRecommend(this);
+    }
 }

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -11,11 +11,7 @@ import sideeffect.project.domain.recruit.RecruitBoard;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import sideeffect.project.domain.comment.Comment;
-import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.recommend.Recommend;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter @Setter

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -8,6 +8,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 import sideeffect.project.domain.comment.Comment;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.recommend.Recommend;
 
 @Entity
 @Getter @Setter
@@ -58,6 +59,10 @@ public class User {
     @OrderBy("id desc")
     private List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<Recommend> recommends = new ArrayList<>();
+
     public void addFreeBoard(FreeBoard freeBoard) {
         this.freeBoards.add(freeBoard);
     }
@@ -72,5 +77,13 @@ public class User {
 
     public void deleteComment(Comment comment) {
         this.comments.remove(comment);
+    }
+
+    public void addRecommend(Recommend recommend) {
+        this.recommends.add(recommend);
+    }
+
+    public void deleteRecommend(Recommend recommend) {
+        this.recommends.remove(recommend);
     }
 }

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -1,7 +1,9 @@
 package sideeffect.project.domain.user;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.*;
 
 import javax.persistence.*;
@@ -60,8 +62,9 @@ public class User {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private List<Recommend> recommends = new ArrayList<>();
+    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+        mappedBy = "user")
+    private Set<Recommend> recommends = new HashSet<>();
 
     public void addFreeBoard(FreeBoard freeBoard) {
         this.freeBoards.add(freeBoard);

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
@@ -23,6 +23,7 @@ public class FreeBoardResponse {
     private String content;
     private String projectUrl;
     private String imgUrl;
+    private int recommends;
     private List<CommentResponse> comments;
 
     public static List<FreeBoardResponse> listOf(List<FreeBoard> freeBoards) {
@@ -40,6 +41,7 @@ public class FreeBoardResponse {
             .content(freeBoard.getContent())
             .projectUrl(freeBoard.getProjectUrl())
             .imgUrl(freeBoard.getImgUrl())
+            .recommends(freeBoard.getRecommends().size())
             .comments(CommentResponse.listOf(freeBoard.getComments()))
             .build();
     }

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
@@ -23,7 +23,7 @@ public class FreeBoardResponse {
     private String content;
     private String projectUrl;
     private String imgUrl;
-    private int recommends;
+    private int recommendation;
     private List<CommentResponse> comments;
 
     public static List<FreeBoardResponse> listOf(List<FreeBoard> freeBoards) {
@@ -41,7 +41,7 @@ public class FreeBoardResponse {
             .content(freeBoard.getContent())
             .projectUrl(freeBoard.getProjectUrl())
             .imgUrl(freeBoard.getImgUrl())
-            .recommends(freeBoard.getRecommends().size())
+            .recommendation(freeBoard.getRecommends().size())
             .comments(CommentResponse.listOf(freeBoard.getComments()))
             .build();
     }

--- a/server/src/main/java/sideeffect/project/dto/recommend/RecommendRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/recommend/RecommendRequest.java
@@ -1,0 +1,14 @@
+package sideeffect.project.dto.recommend;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecommendRequest {
+    private Long userId;
+    private Long freeBoardId;
+}

--- a/server/src/main/java/sideeffect/project/dto/recommend/RecommendResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recommend/RecommendResponse.java
@@ -1,0 +1,26 @@
+package sideeffect.project.dto.recommend;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sideeffect.project.domain.recommend.Recommend;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecommendResponse {
+    private Long boardId;
+    private String userNickname;
+    private String message;
+
+    public static RecommendResponse of(Recommend recommend, RecommendResult message) {
+        return RecommendResponse.builder()
+            .boardId(recommend.getFreeBoard().getId())
+            .userNickname(recommend.getUser().getNickname())
+            .message(message.getMessage())
+            .build();
+    }
+}

--- a/server/src/main/java/sideeffect/project/dto/recommend/RecommendResult.java
+++ b/server/src/main/java/sideeffect/project/dto/recommend/RecommendResult.java
@@ -1,0 +1,17 @@
+package sideeffect.project.dto.recommend;
+
+public enum RecommendResult {
+
+    RECOMMEND("게시글을 추천했습니다."),
+    CANCEL_RECOMMEND("게시글을 추천을 취소했습니다.");
+
+    private final String message;
+
+    RecommendResult(java.lang.String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
@@ -22,4 +22,7 @@ public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long> {
     List<FreeBoard> findStartScrollOfBoard(Pageable pageable);
 
     List<FreeBoard> findByIdLessThanOrderByIdDesc(Long boardId, Pageable pageable);
+
+    @Query("SELECT b from FreeBoard b order by b.recommends.size desc")
+    List<FreeBoard> findRankFreeBoard(Pageable pageable);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecommendRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecommendRepository.java
@@ -1,0 +1,9 @@
+package sideeffect.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sideeffect.project.domain.recommend.Recommend;
+
+public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+
+    boolean existsByUserIdAndFreeBoardId(Long userId, Long freeBoardId);
+}

--- a/server/src/main/java/sideeffect/project/repository/RecommendRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecommendRepository.java
@@ -1,9 +1,12 @@
 package sideeffect.project.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sideeffect.project.domain.recommend.Recommend;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long> {
 
     boolean existsByUserIdAndFreeBoardId(Long userId, Long freeBoardId);
+
+    Optional<Recommend> findByUserIdAndFreeBoardId(Long userId, Long freeBoardId);
 }

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -20,6 +20,8 @@ import sideeffect.project.repository.UserRepository;
 @RequiredArgsConstructor
 public class FreeBoardService {
 
+    private static final int RANK_NUMBER = 6;
+
     private final FreeBoardRepository repository;
     private final UserRepository userRepository;
 
@@ -45,6 +47,11 @@ public class FreeBoardService {
             return findStartScrollBoardWithKeyword(request);
         }
         return findScrollBoardWithKeyword(request);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FreeBoardResponse> findRankFreeBoards() {
+        return FreeBoardResponse.listOf(repository.findRankFreeBoard(Pageable.ofSize(RANK_NUMBER)));
     }
 
     @Transactional

--- a/server/src/main/java/sideeffect/project/service/RecommendService.java
+++ b/server/src/main/java/sideeffect/project/service/RecommendService.java
@@ -1,0 +1,53 @@
+package sideeffect.project.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.recommend.Recommend;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.dto.recommend.RecommendResult;
+import sideeffect.project.dto.recommend.RecommendRequest;
+import sideeffect.project.dto.recommend.RecommendResponse;
+import sideeffect.project.repository.FreeBoardRepository;
+import sideeffect.project.repository.RecommendRepository;
+import sideeffect.project.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+
+    private final RecommendRepository recommendRepository;
+    private final UserRepository userRepository;
+    private final FreeBoardRepository freeBoardRepository;
+
+    @Transactional
+    public RecommendResponse toggleRecommend(RecommendRequest request) {
+        Optional<Recommend> recommend = recommendRepository.findByUserIdAndFreeBoardId(
+            request.getUserId(), request.getFreeBoardId());
+
+        if (recommend.isPresent()) {
+            Recommend recommendFound = recommend.get();
+            cancelRecommend(recommendFound);
+            return RecommendResponse.of(recommendFound, RecommendResult.CANCEL_RECOMMEND);
+        }
+
+        return RecommendResponse.of(recommendBoard(request), RecommendResult.RECOMMEND);
+    }
+
+    private Recommend recommendBoard(RecommendRequest request) {
+        User user = userRepository.findById(request.getUserId())
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        FreeBoard board = freeBoardRepository.findById(request.getFreeBoardId())
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FREE_BOARD_NOT_FOUND));
+        return recommendRepository.save(Recommend.recommend(user, board));
+    }
+
+    private void cancelRecommend(Recommend recommend) {
+        FreeBoard freeBoard = recommend.getFreeBoard();
+        freeBoard.deleteRecommend(recommend);
+    }
+}

--- a/server/src/test/java/sideeffect/project/domain/recommend/RecommendTest.java
+++ b/server/src/test/java/sideeffect/project/domain/recommend/RecommendTest.java
@@ -1,0 +1,45 @@
+package sideeffect.project.domain.recommend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.user.User;
+
+class RecommendTest {
+
+    private User user;
+    private FreeBoard freeBoard;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+            .id(1L)
+            .email("hello@naver.com")
+            .nickname("tester")
+            .password("1234")
+            .build();
+
+        freeBoard = FreeBoard.builder()
+            .id(1L)
+            .content("게시판")
+            .title("제목")
+            .build();
+    }
+
+    @DisplayName("유저가 해당 게시판을 추천한다.")
+    @Test
+    void recommend() {
+        Recommend recommend = Recommend.recommend(user, freeBoard);
+
+        assertAll(
+            () -> assertThat(user.getRecommends()).containsExactly(recommend),
+            () -> assertThat(freeBoard.getRecommends()).containsExactly(recommend),
+            () -> assertThat(recommend.getFreeBoard()).isEqualTo(freeBoard),
+            () -> assertThat(recommend.getUser()).isEqualTo(user)
+        );
+    }
+}

--- a/server/src/test/java/sideeffect/project/repository/RecommendRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecommendRepositoryTest.java
@@ -2,6 +2,7 @@ package sideeffect.project.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,5 +60,24 @@ class RecommendRepositoryTest {
     void notExistsRecommend() {
         boolean result = recommendRepository.existsByUserIdAndFreeBoardId(user.getId(), freeBoard.getId());
         assertThat(result).isFalse();
+    }
+
+    @DisplayName("게시판과 연관관계가 끊기면 자동으로 삭제된다.")
+    @Test
+    void deleteRecommend() {
+        Recommend recommend = Recommend.recommend(user, freeBoard);
+        recommendRepository.saveAndFlush(recommend);
+        em.clear();
+
+        deleteRecommend(recommend.getId());
+        em.flush();
+        em.clear();
+
+        assertThat(recommendRepository.findById(recommend.getId())).isEmpty();
+    }
+
+    private void deleteRecommend(Long id) {
+        Recommend recommend = recommendRepository.findById(id).orElseThrow(EntityExistsException::new);
+        recommend.getFreeBoard().deleteRecommend(recommend);
     }
 }

--- a/server/src/test/java/sideeffect/project/repository/RecommendRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecommendRepositoryTest.java
@@ -1,0 +1,63 @@
+package sideeffect.project.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.recommend.Recommend;
+import sideeffect.project.domain.user.User;
+
+@DataJpaTest
+class RecommendRepositoryTest {
+
+    @Autowired
+    private RecommendRepository recommendRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User user;
+    private FreeBoard freeBoard;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+            .email("test@naver.com")
+            .password("1234")
+            .nickname("tester")
+            .build();
+        em.persist(user);
+
+        freeBoard = FreeBoard.builder()
+            .title("제목")
+            .content("content")
+            .build();
+        freeBoard.associateUser(user);
+        em.persist(freeBoard);
+        em.flush();
+        em.clear();
+    }
+
+    @DisplayName("유저가 해당 게시판이 추천했으면 true 반환")
+    @Test
+    void existsRecommend() {
+        Recommend recommend = Recommend.recommend(user, freeBoard);
+        recommendRepository.saveAndFlush(recommend);
+        em.clear();
+
+        boolean result = recommendRepository.existsByUserIdAndFreeBoardId(user.getId(), freeBoard.getId());
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("유저가 해당 게시판을 추천하지 않았으면 false 반환")
+    @Test
+    void notExistsRecommend() {
+        boolean result = recommendRepository.existsByUserIdAndFreeBoardId(user.getId(), freeBoard.getId());
+        assertThat(result).isFalse();
+    }
+}

--- a/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
@@ -215,6 +215,14 @@ class FreeBoardServiceTest {
         );
     }
 
+    @DisplayName("랭킹 게시판 조회")
+    @Test
+    void findRankFreeBoards() {
+        freeBoardService.findRankFreeBoards();
+
+        verify(freeBoardRepository).findRankFreeBoard(any());
+    }
+
     private static Stream<Arguments> generateScrollTestAugments() {
         return Stream.of(
             Arguments.arguments(FreeBoardScrollRequest.builder().lastId(100L).size(10).build(),

--- a/server/src/test/java/sideeffect/project/service/RecommendServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecommendServiceTest.java
@@ -1,0 +1,100 @@
+package sideeffect.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.domain.recommend.Recommend;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.dto.recommend.RecommendResult;
+import sideeffect.project.dto.recommend.RecommendRequest;
+import sideeffect.project.dto.recommend.RecommendResponse;
+import sideeffect.project.repository.FreeBoardRepository;
+import sideeffect.project.repository.RecommendRepository;
+import sideeffect.project.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendServiceTest {
+
+    private RecommendService recommendService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FreeBoardRepository freeBoardRepository;
+
+    @Mock
+    private RecommendRepository recommendRepository;
+
+    private User user;
+    private FreeBoard freeBoard;
+    private Recommend recommend;
+
+    @BeforeEach
+    void setUp() {
+        recommendService = new RecommendService(recommendRepository, userRepository, freeBoardRepository);
+
+        user = User.builder()
+            .id(1L)
+            .email("test@naver.com")
+            .nickname("tester")
+            .password("1234")
+            .build();
+
+        freeBoard = FreeBoard.builder()
+            .id(1L)
+            .title("게시판입니다.")
+            .projectUrl("url")
+            .imgUrl("/test.jpg")
+            .content("test")
+            .build();
+
+        recommend = Recommend.recommend(user, freeBoard);
+    }
+
+    @DisplayName("유저가 게시판을 추천한다.")
+    @Test
+    void recommendBoard() {
+        when(recommendRepository.findByUserIdAndFreeBoardId(any(), any())).thenReturn(Optional.empty());
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(freeBoardRepository.findById(any())).thenReturn(Optional.of(freeBoard));
+        when(recommendRepository.save(any())).thenReturn(recommend);
+        RecommendRequest request = new RecommendRequest(user.getId(), freeBoard.getId());
+
+        RecommendResponse response = recommendService.toggleRecommend(request);
+
+        assertAll(
+            () -> verify(recommendRepository).findByUserIdAndFreeBoardId(any(), any()),
+            () -> verify(userRepository).findById(any()),
+            () -> verify(freeBoardRepository).findById(any()),
+            () -> verify(recommendRepository).save(any()),
+            () -> assertThat(response.getMessage()).isEqualTo(RecommendResult.RECOMMEND.getMessage())
+        );
+    }
+
+    @DisplayName("유저가 게시판 추천을 취소한다.")
+    @Test
+    void cancelRecommend() {
+        when(recommendRepository.findByUserIdAndFreeBoardId(any(), any())).thenReturn(Optional.of(recommend));
+        RecommendRequest request = new RecommendRequest(user.getId(), freeBoard.getId());
+
+        RecommendResponse response = recommendService.toggleRecommend(request);
+
+        assertAll(
+            () -> verify(recommendRepository).findByUserIdAndFreeBoardId(any(), any()),
+            () -> assertThat(response.getMessage()).isEqualTo(RecommendResult.CANCEL_RECOMMEND.getMessage()),
+            () -> assertThat(freeBoard.getRecommends()).doesNotContain(recommend)
+        );
+    }
+}


### PR DESCRIPTION
다음의 기능을 구현했습니다.
- 게시판 추천 기능을 구현했습니다. (토글 형식으로 구현)
- 자랑 게시판 api의 url을 변경했습니다. (단수형 -> 복수형)
- 랭킹 기능을 구현했습니다. 
  (1주전, 1달전 추천을 기준으로 하려면 native query나 querydsl을 사용해야 합니다. 따라서 전체 추천 기준으로 정했습니다.)