### PR TITLE
Feat/common Querydsl관련 설정

### DIFF
--- a/server/src/main/java/sideeffect/project/config/QuerydslConfiguration.java
+++ b/server/src/main/java/sideeffect/project/config/QuerydslConfiguration.java
@@ -1,0 +1,20 @@
+package sideeffect.project.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfiguration {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/common/jpa/TestDataRepository.java
+++ b/server/src/test/java/sideeffect/project/common/jpa/TestDataRepository.java
@@ -1,0 +1,10 @@
+package sideeffect.project.common.jpa;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TestQuerydslConfiguration.class)
+public class TestDataRepository {
+
+}

--- a/server/src/test/java/sideeffect/project/common/jpa/TestQuerydslConfiguration.java
+++ b/server/src/test/java/sideeffect/project/common/jpa/TestQuerydslConfiguration.java
@@ -1,0 +1,22 @@
+package sideeffect.project.common.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import sideeffect.project.config.JpaAuditingConfig;
+
+@Import(JpaAuditingConfig.class)
+@TestConfiguration
+public class TestQuerydslConfiguration {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/server/src/test/java/sideeffect/project/domain/common/BaseTimeEntityTest.java
+++ b/server/src/test/java/sideeffect/project/domain/common/BaseTimeEntityTest.java
@@ -1,12 +1,13 @@
-package sideeffect.project.common.domain;
+package sideeffect.project.domain.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import sideeffect.project.config.JpaAuditingConfig;
+import sideeffect.project.common.jpa.TestDataRepository;
 import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.repository.FreeBoardRepository;
@@ -15,12 +16,7 @@ import sideeffect.project.repository.UserRepository;
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-@Import(JpaAuditingConfig.class)
-@DataJpaTest
-class BaseTimeEntityTest {
+class BaseTimeEntityTest extends TestDataRepository {
 
     @Autowired
     private FreeBoardRepository freeBoardRepository;


### PR DESCRIPTION
다음을 구현했습니다.
- Querydsl 관련 빈 configuration class
- @DataJpaTest를 대체한 공통 레파지토리 테스트 구현
    - Querydsl 사용 시 @DataJpaTest에서 빈 주입 오류가 발생해서 대체 클래스 구현
    - BaseTimeEntityTest에 예시로 있습니다.