### PR TITLE
Feat/freeboard 자랑 게시판 Qeurydsl 적용과 Dto 수정

### DIFF
--- a/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
+++ b/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
     USER_ALREADY_EXIST(400, "U_003", "이미 존재하는 이메일입니다"),
 
     FREE_BOARD_NOT_FOUND(400, "FB_001", "해당 게시판을 찾을 수 없습니다."),
+    FREE_BOARD_UNAUTHORIZED(403, "FB_002", "해당 게시판에 대한 권한이 없습니다."),
 
     COMMENT_NOT_FOUND(400, "CM_001", "해당 댓글을 찾을 수 없습니다."),
     COMMENT_UNAUTHORIZED(403, "CM_002", "해당 댓글에 대한 권한이 없습니다."),

--- a/server/src/main/java/sideeffect/project/config/WebSecurityConfig.java
+++ b/server/src/main/java/sideeffect/project/config/WebSecurityConfig.java
@@ -55,6 +55,7 @@ public class WebSecurityConfig{
                 .authorizeRequests()
                     .antMatchers("/join").permitAll()
                     .antMatchers(HttpMethod.POST, "/**").authenticated()
+                    .antMatchers(HttpMethod.GET, "/api/free-boards/**").permitAll()
                     .and()
                 .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -35,13 +35,13 @@ public class FreeBoardController {
     }
 
     @GetMapping("/scroll")
-    public FreeBoardScrollResponse scrollBoard(@ModelAttribute FreeBoardScrollRequest request) {
-        return freeBoardService.findScroll(request);
+    public FreeBoardScrollResponse scrollBoard(@ModelAttribute FreeBoardScrollRequest request, @LoginUser User user) {
+        return freeBoardService.findScroll(request, user.getId());
     }
 
     @GetMapping("/search")
-    public FreeBoardScrollResponse searchBoard(@ModelAttribute FreeBoardKeyWordRequest request) {
-        return freeBoardService.findScrollWithKeyword(request);
+    public FreeBoardScrollResponse searchBoard(@ModelAttribute FreeBoardKeyWordRequest request, @LoginUser User user) {
+        return freeBoardService.findScrollWithKeyword(request, user.getId());
     }
 
     @GetMapping("/rank")

--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -2,15 +2,23 @@ package sideeffect.project.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sideeffect.project.domain.user.User;
 import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
+import sideeffect.project.dto.freeboard.FreeBoardRequest;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
+import sideeffect.project.security.LoginUser;
 import sideeffect.project.service.FreeBoardService;
 
 @RestController
@@ -38,5 +46,25 @@ public class FreeBoardController {
     @GetMapping("/rank")
     public List<FreeBoardResponse> getRankBoard() {
         return freeBoardService.findRankFreeBoards();
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PostMapping
+    public FreeBoardResponse registerBoard(@RequestBody FreeBoardRequest request, @LoginUser User user) {
+        return FreeBoardResponse.of(freeBoardService.register(user, request));
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PatchMapping("/{id}")
+    public void updateBoard(@PathVariable("id") Long boardId,
+        @RequestBody FreeBoardRequest request,
+        @LoginUser User user) {
+        freeBoardService.updateBoard(user.getId(), boardId, request);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public void deleteBoard(@PathVariable("id") Long boardId, @LoginUser User user) {
+        freeBoardService.deleteBoard(user.getId(), boardId);
     }
 }

--- a/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/FreeBoardController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
+import sideeffect.project.dto.freeboard.DetailedFreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
@@ -29,7 +30,7 @@ public class FreeBoardController {
     private final FreeBoardService freeBoardService;
 
     @GetMapping("/{id}")
-    public FreeBoardResponse findBoard(@PathVariable Long id) {
+    public DetailedFreeBoardResponse findBoard(@PathVariable Long id) {
         return freeBoardService.findBoard(id);
     }
 

--- a/server/src/main/java/sideeffect/project/dto/freeboard/DetailedFreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/DetailedFreeBoardResponse.java
@@ -1,6 +1,5 @@
 package sideeffect.project.dto.freeboard;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -9,44 +8,41 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.dto.comment.CommentResponse;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class FreeBoardResponse {
+public class DetailedFreeBoardResponse {
 
     private Long id;
     private int views;
-    private String userNickname;
+    private Long userId;
     private String title;
     private String content;
     private String projectUrl;
-    private String headerImage;
-    private int recommendations;
-    private boolean recommend;
-    private int commentNumber;
-    private LocalDateTime createAt;
+    private String imgUrl;
+    private int recommendation;
+    private List<CommentResponse> comments;
 
-
-    public static List<FreeBoardResponse> listOf(List<FreeBoard> freeBoards) {
+    public static List<DetailedFreeBoardResponse> listOf(List<FreeBoard> freeBoards) {
         return freeBoards.stream()
-            .map(FreeBoardResponse::of)
+            .map(DetailedFreeBoardResponse::of)
             .collect(Collectors.toList());
     }
 
-    public static FreeBoardResponse of(FreeBoard freeBoard) {
-        return FreeBoardResponse.builder()
+    public static DetailedFreeBoardResponse of(FreeBoard freeBoard) {
+        return DetailedFreeBoardResponse.builder()
             .id(freeBoard.getId())
             .views(freeBoard.getViews())
             .title(freeBoard.getTitle())
-            .userNickname(freeBoard.getUser().getNickname())
+            .userId(freeBoard.getUser().getId())
             .content(freeBoard.getContent())
             .projectUrl(freeBoard.getProjectUrl())
-            .headerImage(freeBoard.getImgUrl())
-            .recommendations(freeBoard.getRecommends().size())
-            .commentNumber(freeBoard.getComments().size())
-            .createAt(freeBoard.getCreateAt())
+            .imgUrl(freeBoard.getImgUrl())
+            .recommendation(freeBoard.getRecommends().size())
+            .comments(CommentResponse.listOf(freeBoard.getComments()))
             .build();
     }
 }

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardRequest.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 import sideeffect.project.domain.freeboard.FreeBoard;
 
 @Getter
@@ -17,7 +16,6 @@ public class FreeBoardRequest {
     private String title;
     private String projectUrl;
     private String content;
-    private MultipartFile multipartFile;
 
     public FreeBoard toFreeBoard() {
         return FreeBoard.builder()

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
@@ -1,5 +1,7 @@
 package sideeffect.project.dto.freeboard;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,10 +10,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import sideeffect.project.domain.freeboard.FreeBoard;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FreeBoardResponse {
@@ -24,8 +28,10 @@ public class FreeBoardResponse {
     private String projectUrl;
     private String headerImage;
     private int recommendations;
-    private boolean recommend;
     private int commentNumber;
+    private boolean recommend;
+
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     private LocalDateTime createAt;
 
 

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardResponse.java
@@ -25,9 +25,8 @@ public class FreeBoardResponse {
     private String userNickname;
     private String title;
     private String content;
-    private String projectUrl;
     private String headerImage;
-    private int recommendations;
+    private int recommendNumber;
     private int commentNumber;
     private boolean recommend;
 
@@ -48,9 +47,8 @@ public class FreeBoardResponse {
             .title(freeBoard.getTitle())
             .userNickname(freeBoard.getUser().getNickname())
             .content(freeBoard.getContent())
-            .projectUrl(freeBoard.getProjectUrl())
             .headerImage(freeBoard.getImgUrl())
-            .recommendations(freeBoard.getRecommends().size())
+            .recommendNumber(freeBoard.getRecommends().size())
             .commentNumber(freeBoard.getComments().size())
             .createAt(freeBoard.getCreateAt())
             .build();

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardScrollDto.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardScrollDto.java
@@ -1,0 +1,22 @@
+package sideeffect.project.dto.freeboard;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FreeBoardScrollDto {
+
+    private Long lastId;
+
+    private int size;
+
+    private String keyWord;
+
+}

--- a/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardScrollResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/freeboard/FreeBoardScrollResponse.java
@@ -17,6 +17,13 @@ public class FreeBoardScrollResponse {
     private boolean hasNext;
 
     public static FreeBoardScrollResponse of(List<FreeBoardResponse> freeBoards, boolean hasNext) {
+        if (freeBoards.isEmpty()) {
+            return FreeBoardScrollResponse.builder()
+                .freeBoards(freeBoards)
+                .hasNext(hasNext)
+                .build();
+        }
+
         return FreeBoardScrollResponse.builder()
             .freeBoards(freeBoards)
             .lastId(freeBoards.get(freeBoards.size() - 1).getId())

--- a/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/FreeBoardRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sideeffect.project.domain.freeboard.FreeBoard;
+import sideeffect.project.repository.freeboard.FreeBoardRepositoryCustom;
 
-public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long> {
+public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long>, FreeBoardRepositoryCustom {
 
     @Query("SELECT b from FreeBoard b where b.content like %:keyword% or b.title like %:keyword% "
     + "order by b.id desc")

--- a/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryCustom.java
+++ b/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryCustom.java
@@ -1,0 +1,12 @@
+package sideeffect.project.repository.freeboard;
+
+
+import java.util.List;
+import sideeffect.project.dto.freeboard.FreeBoardResponse;
+
+public interface FreeBoardRepositoryCustom {
+
+    List<FreeBoardResponse> searchScroll(Long lastId, Long userId, int size);
+
+    List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, int size);
+}

--- a/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryCustom.java
+++ b/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryCustom.java
@@ -6,7 +6,7 @@ import sideeffect.project.dto.freeboard.FreeBoardResponse;
 
 public interface FreeBoardRepositoryCustom {
 
-    List<FreeBoardResponse> searchScroll(Long lastId, Long userId, int size);
+    List<FreeBoardResponse> searchScroll(Long lastId, Long userId, Integer size);
 
-    List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, int size);
+    List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, Integer size);
 }

--- a/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
@@ -24,7 +24,7 @@ public class FreeBoardRepositoryImpl implements FreeBoardRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<FreeBoardResponse> searchScroll(Long lastId, Long userId, int size) {
+    public List<FreeBoardResponse> searchScroll(Long lastId, Long userId, Integer size) {
         return jpaQueryFactory.select(getResponseConstructor(userId))
             .from(freeBoard)
             .where(boardIdLt(lastId))
@@ -34,7 +34,7 @@ public class FreeBoardRepositoryImpl implements FreeBoardRepositoryCustom {
     }
 
     @Override
-    public List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, int size) {
+    public List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, Integer size) {
         return jpaQueryFactory.select(getResponseConstructor(userId))
             .from(freeBoard)
             .where(boardIdLt(lastId),

--- a/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
@@ -51,7 +51,6 @@ public class FreeBoardRepositoryImpl implements FreeBoardRepositoryCustom {
             freeBoard.user.nickname,
             freeBoard.title,
             freeBoard.content,
-            freeBoard.projectUrl,
             freeBoard.imgUrl,
             freeBoard.recommends.size(),
             freeBoard.comments.size(),

--- a/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/freeboard/FreeBoardRepositoryImpl.java
@@ -1,0 +1,80 @@
+package sideeffect.project.repository.freeboard;
+
+import static sideeffect.project.domain.freeboard.QFreeBoard.freeBoard;
+import static sideeffect.project.domain.recommend.QRecommend.recommend;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import sideeffect.project.dto.freeboard.FreeBoardResponse;
+
+
+@Repository
+@RequiredArgsConstructor
+public class FreeBoardRepositoryImpl implements FreeBoardRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<FreeBoardResponse> searchScroll(Long lastId, Long userId, int size) {
+        return jpaQueryFactory.select(getResponseConstructor(userId))
+            .from(freeBoard)
+            .where(boardIdLt(lastId))
+            .orderBy(freeBoard.id.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<FreeBoardResponse> searchScrollWithKeyword(Long lastId, Long userId, String keyword, int size) {
+        return jpaQueryFactory.select(getResponseConstructor(userId))
+            .from(freeBoard)
+            .where(boardIdLt(lastId),
+                freeBoard.content.containsIgnoreCase(keyword).or(freeBoard.title.containsIgnoreCase(keyword)))
+            .orderBy(freeBoard.id.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    private ConstructorExpression<FreeBoardResponse> getResponseConstructor(Long userId) {
+        return Projections.constructor(FreeBoardResponse.class,
+            freeBoard.id,
+            freeBoard.views,
+            freeBoard.user.nickname,
+            freeBoard.title,
+            freeBoard.content,
+            freeBoard.projectUrl,
+            freeBoard.imgUrl,
+            freeBoard.recommends.size(),
+            freeBoard.comments.size(),
+            getLikeExpression(userId),
+            freeBoard.createAt);
+    }
+
+
+    private BooleanExpression boardIdLt(Long boardId) {
+        if (boardId != null) {
+            return freeBoard.id.lt(boardId);
+        }
+        return null;
+    }
+
+    private Expression<Boolean> getLikeExpression(Long userId) {
+        if (userId == null) {
+            return Expressions.asBoolean(false).isTrue();
+        }
+        return ExpressionUtils.as(JPAExpressions.selectOne()
+                .from(recommend)
+                .where(recommend.user.id.eq(userId).and(recommend.freeBoard.id.eq(freeBoard.id))).limit(1).isNotNull(),
+            "like");
+
+    }
+}

--- a/server/src/main/java/sideeffect/project/service/FreeBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/FreeBoardService.java
@@ -12,6 +12,7 @@ import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.dto.freeboard.FreeBoardKeyWordRequest;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
+import sideeffect.project.dto.freeboard.DetailedFreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
@@ -54,10 +55,10 @@ public class FreeBoardService {
     }
 
     @Transactional(readOnly = true)
-    public FreeBoardResponse findBoard(Long boardId) {
+    public DetailedFreeBoardResponse findBoard(Long boardId) {
         FreeBoard freeBoard = findFreeBoard(boardId);
         freeBoard.increaseViews();
-        return FreeBoardResponse.of(freeBoard);
+        return DetailedFreeBoardResponse.of(freeBoard);
     }
 
     @Transactional

--- a/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
@@ -41,6 +41,7 @@ import sideeffect.project.domain.recommend.Recommend;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
 import sideeffect.project.dto.freeboard.FreeBoardRequest;
+import sideeffect.project.dto.freeboard.DetailedFreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardResponse;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
 import sideeffect.project.security.UserDetailsServiceImpl;
@@ -98,7 +99,7 @@ class FreeBoardControllerTest {
         List<Comment> freeBoards = generateComments(1L, 10L);
         freeBoards.forEach(comment -> comment.associate(user, freeBoard));
         recommend(recommendNumber, freeBoard);
-        FreeBoardResponse response = FreeBoardResponse.of(freeBoard);
+        DetailedFreeBoardResponse response = DetailedFreeBoardResponse.of(freeBoard);
         given(freeBoardService.findBoard(any())).willReturn(response);
 
         mvc.perform(get("/api/free-boards/1")

--- a/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/FreeBoardControllerTest.java
@@ -125,7 +125,7 @@ class FreeBoardControllerTest {
         associateCommentsAndFreeBoards(freeBoards, generateComments(81L, 100L));
         List<FreeBoardResponse> responses = FreeBoardResponse.listOf(freeBoards);
         FreeBoardScrollResponse scrollResponse = FreeBoardScrollResponse.of(responses, true);
-        given(freeBoardService.findScroll(any())).willReturn(scrollResponse);
+        given(freeBoardService.findScroll(any(), any())).willReturn(scrollResponse);
 
         mvc.perform(get("/api/free-boards/scroll")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/FreeBoardRepositoryTest.java
@@ -14,14 +14,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Pageable;
+import sideeffect.project.common.jpa.TestDataRepository;
 import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.recommend.Recommend;
 import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+import sideeffect.project.dto.freeboard.FreeBoardResponse;
 
-@DataJpaTest
-class FreeBoardRepositoryTest {
+class FreeBoardRepositoryTest extends TestDataRepository {
 
     @Autowired
     private FreeBoardRepository repository;
@@ -29,14 +30,25 @@ class FreeBoardRepositoryTest {
     @Autowired
     private EntityManager em;
 
+    private User user;
+
     @BeforeEach
     void setUp() {
+        user = User.builder()
+            .email("tester@naver.com")
+            .password("1234")
+            .nickname("hello")
+            .userRoleType(UserRoleType.ROLE_USER)
+            .build();
+        em.persist(user);
         List<FreeBoard> freeBoards = new ArrayList<>();
         for (int i = 0; i < 20 ; i++) {
             FreeBoard freeBoard = FreeBoard.builder().title("게시판" + i).content("내용" + i).build();
             freeBoards.add(freeBoard);
+            freeBoard.associateUser(user);
         }
         repository.saveAll(freeBoards);
+        em.flush();
         em.clear();
     }
 
@@ -45,6 +57,7 @@ class FreeBoardRepositoryTest {
     void findAllByContentContaining() {
         String content = "검색할 내용";
         FreeBoard freeBoard = FreeBoard.builder().title("게시판").content("----" + content + "abcde").build();
+        freeBoard.associateUser(user);
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
@@ -58,6 +71,7 @@ class FreeBoardRepositoryTest {
     void findAllByTitleContaining() {
         String title = "검색할 제목";
         FreeBoard freeBoard = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        freeBoard.associateUser(user);
         repository.save(freeBoard);
         repository.save(FreeBoard.builder().title("다른 게시판").content("1234").build());
 
@@ -85,6 +99,44 @@ class FreeBoardRepositoryTest {
         );
     }
 
+    @DisplayName("게시판의 목록 중 마지막 게시판을 querydsl 조회")
+    @Test
+    void searchScroll() {
+        int pagingSize = 5;
+        Long lastId = getLastId();
+        List<Long> answerBoardIds =
+            LongStream.rangeClosed(lastId - pagingSize + 1, lastId).sorted().boxed().collect(Collectors.toList());
+        Collections.reverse(answerBoardIds);
+
+        List<FreeBoardResponse> freeBoards = repository
+            .searchScroll(null, null, pagingSize);
+        List<Long> resultBoardId = freeBoards.stream().map(FreeBoardResponse::getId).collect(Collectors.toList());
+
+        assertAll(
+            () -> assertThat(freeBoards).hasSize(pagingSize),
+            () -> assertThat(resultBoardId).isEqualTo(answerBoardIds)
+        );
+    }
+
+    @DisplayName("스크롤 페이징 방식으로 querydsl 조회")
+    @Test
+    void searchScrollByBoardId() {
+        Long lastId = getLastId();
+        List<Long> answerBoardIds =
+            LongStream.rangeClosed(lastId - 19, lastId - 10).sorted().boxed().collect(Collectors.toList());
+        Collections.reverse(answerBoardIds);
+
+        List<FreeBoardResponse> freeBoards = repository
+            .searchScroll(lastId - 9, null, 10);
+        List<Long> resultBoardId = freeBoards.stream().map(FreeBoardResponse::getId).collect(Collectors.toList());
+
+        assertAll(
+            () -> assertThat(freeBoards).hasSize(10),
+            () -> assertThat(resultBoardId).isEqualTo(answerBoardIds)
+        );
+    }
+
+
     @DisplayName("스크롤 페이징 방식으로 조회")
     @Test
     void findByPaging() {
@@ -101,6 +153,27 @@ class FreeBoardRepositoryTest {
             () -> assertThat(freeBoards).hasSize(10),
             () -> assertThat(resultBoardId).isEqualTo(answerBoardIds)
         );
+    }
+
+    @DisplayName("검색 결과를 페이징 방식으로 querydsl 조회")
+    @Test
+    void searchFreeBoardScrollWithKeyWord() {
+        String title = "검색할 제목";
+        FreeBoard freeBoard1 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        FreeBoard freeBoard2 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        FreeBoard freeBoard3 = FreeBoard.builder().title("게시판" + title).content("내용").build();
+        freeBoard1.associateUser(user);
+        freeBoard2.associateUser(user);
+        freeBoard3.associateUser(user);
+        repository.save(freeBoard1);
+        repository.save(freeBoard2);
+        repository.save(freeBoard3);
+
+        List<FreeBoardResponse> boards = repository
+            .searchScrollWithKeyword(freeBoard2.getId() + 1, null, title, 5);
+        List<Long> boardIds = boards.stream().map(FreeBoardResponse::getId).collect(Collectors.toList());
+
+        assertThat(boardIds).containsExactly(freeBoard2.getId(), freeBoard1.getId());
     }
 
     @DisplayName("검색 결과를 페이징 방식으로 조회")

--- a/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/FreeBoardServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sideeffect.project.common.exception.AuthException;
 import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
@@ -17,7 +18,7 @@ import sideeffect.project.dto.freeboard.FreeBoardRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollRequest;
 import sideeffect.project.dto.freeboard.FreeBoardScrollResponse;
 import sideeffect.project.repository.FreeBoardRepository;
-import sideeffect.project.repository.UserRepository;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,15 +40,12 @@ class FreeBoardServiceTest {
     @Mock
     private FreeBoardRepository freeBoardRepository;
 
-    @Mock
-    private UserRepository userRepository;
-
     private FreeBoard freeBoard;
     private User user;
 
     @BeforeEach
     void setUp() {
-        freeBoardService = new FreeBoardService(freeBoardRepository, userRepository);
+        freeBoardService = new FreeBoardService(freeBoardRepository);
 
         user = User.builder()
             .id(1L)
@@ -71,10 +69,8 @@ class FreeBoardServiceTest {
     void register() {
         FreeBoardRequest request = FreeBoardRequest.builder()
             .title("자랑 게시판").content("제가 만든 겁니다.").projectUrl("url").build();
-        Long userId = 1L;
-        when(userRepository.findById(any())).thenReturn(Optional.of(user));
 
-        freeBoardService.register(userId, request);
+        freeBoardService.register(user, request);
 
         verify(freeBoardRepository).save(any());
     }
@@ -108,7 +104,7 @@ class FreeBoardServiceTest {
         when(freeBoardRepository.findById(any())).thenReturn(Optional.of(freeBoard));
 
         assertThatThrownBy(() -> freeBoardService.updateBoard(nonOwnerId, boardId, request))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(AuthException.class);
     }
 
     @DisplayName("게시판을 단건 조회한다.")
@@ -142,7 +138,7 @@ class FreeBoardServiceTest {
         when(freeBoardRepository.findById(any())).thenReturn(Optional.of(freeBoard));
 
         assertThatThrownBy(() -> freeBoardService.deleteBoard(nonOwnerId, 1L))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(AuthException.class);
     }
 
     @DisplayName("게시판을 스크롤 조회한다.")


### PR DESCRIPTION
다음의 기능을 구현했습니다.
- 자랑 게시판 검색과 조회 스크롤에 querydsl 적용과 Dto로 반환하도록 함
- Response 필드 수정과 빈 배열이 들어가면 오류가 발생하는 버그 해결
- 게시판 수정, 등록, 삭제 기능을 컨트롤러에 동작하도록 했습니다.