### PR TITLE
Feat/applicant 모집 게시판 지원 기능 구현

### DIFF
--- a/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
+++ b/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
@@ -15,8 +15,9 @@ public enum ErrorCode {
     BOARD_POSITION_NOT_FOUND(400, "BP_001", "해당 게시판이 모집하는 포지션을 찾을 수 없습니다."),
 
     APPLICANT_NOT_FOUND(400, "AC_001", "지원자를 찾을 수 없습니다."),
-    APPLICANT_SELF_UNAUTHORIZED(403, "AC_002", "본인의 게시물에는 지원할 수 없습니다."),
-    APPLICANT_DUPLICATED(403, "AC_003", "하나의 게시물에는 한 번만 지원할 수 있습니다."),
+    APPLICANT_UNAUTHORIZED(403, "AC_002", "해당 지원자 목록에 대한 권한이 없습니다."),
+    APPLICANT_SELF_UNAUTHORIZED(403, "AC_003", "본인의 게시물에는 지원할 수 없습니다."),
+    APPLICANT_DUPLICATED(403, "AC_004", "하나의 게시물에는 한 번만 지원할 수 있습니다."),
 
     POSITION_NOT_FOUND(400, "PS_001", "해당 포지션을 찾을 수 없습니다."),
 

--- a/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
+++ b/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
@@ -13,11 +13,14 @@ public enum ErrorCode {
     RECRUIT_BOARD_UNAUTHORIZED(403, "RB_002", "해당 모집 게시판에 대한 권한이 없습니다."),
 
     BOARD_POSITION_NOT_FOUND(400, "BP_001", "해당 게시판이 모집하는 포지션을 찾을 수 없습니다."),
+    BOARD_POSITION_FULL(409, "BP_002", "해당 포지션은 전부 모집되었습니다."),
 
     APPLICANT_NOT_FOUND(400, "AC_001", "지원자를 찾을 수 없습니다."),
     APPLICANT_UNAUTHORIZED(403, "AC_002", "해당 지원자 목록에 대한 권한이 없습니다."),
     APPLICANT_SELF_UNAUTHORIZED(403, "AC_003", "본인의 게시물에는 지원할 수 없습니다."),
     APPLICANT_DUPLICATED(403, "AC_004", "하나의 게시물에는 한 번만 지원할 수 있습니다."),
+    APPLICANT_EXISTS(409, "AC_005", "해당 지원자는 이미 팀원으로 합류가 되어있습니다."),
+    APPLICANT_NOT_EXISTS(409, "AC_006", "해당 팀원은 존재하지 않습니다."),
 
     POSITION_NOT_FOUND(400, "PS_001", "해당 포지션을 찾을 수 없습니다."),
 

--- a/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
+++ b/server/src/main/java/sideeffect/project/common/exception/ErrorCode.java
@@ -12,6 +12,12 @@ public enum ErrorCode {
     RECRUIT_BOARD_NOT_FOUND(400, "RB_001", "해당 모집 게시판을 찾을 수 없습니다."),
     RECRUIT_BOARD_UNAUTHORIZED(403, "RB_002", "해당 모집 게시판에 대한 권한이 없습니다."),
 
+    BOARD_POSITION_NOT_FOUND(400, "BP_001", "해당 게시판이 모집하는 포지션을 찾을 수 없습니다."),
+
+    APPLICANT_NOT_FOUND(400, "AC_001", "지원자를 찾을 수 없습니다."),
+    APPLICANT_SELF_UNAUTHORIZED(403, "AC_002", "본인의 게시물에는 지원할 수 없습니다."),
+    APPLICANT_DUPLICATED(403, "AC_003", "하나의 게시물에는 한 번만 지원할 수 있습니다."),
+
     POSITION_NOT_FOUND(400, "PS_001", "해당 포지션을 찾을 수 없습니다."),
 
     STACK_NOT_FOUND(400, "ST_001", "해당 기술스택을 찾을 수 없습니다.");

--- a/server/src/main/java/sideeffect/project/controller/ApplicantController.java
+++ b/server/src/main/java/sideeffect/project/controller/ApplicantController.java
@@ -1,0 +1,54 @@
+package sideeffect.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import sideeffect.project.domain.applicant.ApplicantStatus;
+import sideeffect.project.domain.position.PositionType;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.dto.applicant.*;
+import sideeffect.project.security.LoginUser;
+import sideeffect.project.service.ApplicantService;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/applicant")
+public class ApplicantController {
+
+    private final ApplicantService applicantService;
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PostMapping
+    public ApplicantResponse registerApplicant(@LoginUser User user, @RequestBody ApplicantRequest request) {
+        return applicantService.register(user, request);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @GetMapping("list/{boardId}")
+    public Map<PositionType, ApplicantPositionResponse> findApplicants(
+            @LoginUser User user,
+            @PathVariable Long boardId,
+            @RequestParam(value = "status") ApplicantStatus status
+    ) {
+        return applicantService.findApplicants(user.getId(), boardId, status);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PutMapping
+    public void updateApplicant(@LoginUser User user, @RequestBody ApplicantUpdateRequest request) {
+        if(request.getStatus().equals(ApplicantStatus.APPROVED)) {
+            applicantService.approveApplicant(user.getId(), request);
+        }else if(request.getStatus().equals(ApplicantStatus.REJECTED)) {
+            applicantService.rejectApplicant(user.getId(), request);
+        }
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PutMapping("/release")
+    public void releaseApplicant(@LoginUser User user, @RequestBody ApplicantReleaseRequest request) {
+        applicantService.releaseApplicant(user.getId(), request);
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/domain/applicant/Applicant.java
+++ b/server/src/main/java/sideeffect/project/domain/applicant/Applicant.java
@@ -24,11 +24,11 @@ public class Applicant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ApplicantStatus status;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_position_id")
     private BoardPosition boardPosition;
 
@@ -41,7 +41,12 @@ public class Applicant extends BaseTimeEntity {
     public void associate(User user, BoardPosition boardPosition) {
         boardPosition.addApplicant(this);
         user.addApplicant(this);
-        this.user =user;
+        this.user = user;
         this.boardPosition = boardPosition;
     }
+
+    public void updateStatus(ApplicantStatus status) {
+        this.status = status;
+    }
+
 }

--- a/server/src/main/java/sideeffect/project/domain/applicant/Applicant.java
+++ b/server/src/main/java/sideeffect/project/domain/applicant/Applicant.java
@@ -1,0 +1,47 @@
+package sideeffect.project.domain.applicant;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sideeffect.project.common.domain.BaseTimeEntity;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.user.User;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "APPLICANT")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Applicant extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "applicant_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicantStatus status;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "board_position_id")
+    private BoardPosition boardPosition;
+
+    @Builder
+    public Applicant(Long id) {
+        this.id = id;
+        this.status = ApplicantStatus.PENDING;
+    }
+
+    public void associate(User user, BoardPosition boardPosition) {
+        boardPosition.addApplicant(this);
+        user.addApplicant(this);
+        this.user =user;
+        this.boardPosition = boardPosition;
+    }
+}

--- a/server/src/main/java/sideeffect/project/domain/applicant/ApplicantStatus.java
+++ b/server/src/main/java/sideeffect/project/domain/applicant/ApplicantStatus.java
@@ -1,0 +1,5 @@
+package sideeffect.project.domain.applicant;
+
+public enum ApplicantStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
@@ -4,9 +4,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sideeffect.project.domain.applicant.Applicant;
 import sideeffect.project.domain.position.Position;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "BOARD_POSITION")
@@ -34,16 +37,25 @@ public class BoardPosition {
     @JoinColumn(name = "recruit_board_id")
     private RecruitBoard recruitBoard;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "boardPosition")
+    private List<Applicant> applicants;
+
     @Builder
-    public BoardPosition(int targetNumber, Position position, RecruitBoard recruitBoard) {
+    public BoardPosition(Long id, int targetNumber, Position position, RecruitBoard recruitBoard) {
+        this.id = id;
         this.targetNumber = targetNumber;
         this.currentNumber = 0;
         this.position = position;
         this.recruitBoard = recruitBoard;
+        this.applicants = new ArrayList<>();
     }
 
     public void setRecruitBoard(RecruitBoard recruitBoard) {
         this.recruitBoard = recruitBoard;
+    }
+
+    public void addApplicant(Applicant applicant) {
+        this.applicants.add(applicant);
     }
 
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/BoardPosition.java
@@ -58,4 +58,16 @@ public class BoardPosition {
         this.applicants.add(applicant);
     }
 
+    public void increaseCurrentNumber() {
+        if(this.currentNumber < this.targetNumber) {
+            this.currentNumber++;
+        }
+    }
+
+    public void decreaseCurrentNumber() {
+        if(this.currentNumber > 0) {
+            this.currentNumber--;
+        }
+    }
+
 }

--- a/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
+++ b/server/src/main/java/sideeffect/project/domain/recruit/RecruitBoard.java
@@ -42,7 +42,7 @@ public class RecruitBoard extends BaseTimeEntity {
 
     private LocalDateTime deadline;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/server/src/main/java/sideeffect/project/domain/user/User.java
+++ b/server/src/main/java/sideeffect/project/domain/user/User.java
@@ -1,6 +1,7 @@
 package sideeffect.project.domain.user;
 
 import lombok.*;
+import sideeffect.project.domain.applicant.Applicant;
 import sideeffect.project.domain.comment.Comment;
 import sideeffect.project.domain.freeboard.FreeBoard;
 import sideeffect.project.domain.recruit.RecruitBoard;
@@ -64,6 +65,10 @@ public class User {
     @OrderBy("id desc")
     private List<RecruitBoard> recruitBoards = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+    @OrderBy("id desc")
+    private List<Applicant> applicants = new ArrayList<>();
 
     public void addFreeBoard(FreeBoard freeBoard) {
         this.freeBoards.add(freeBoard);
@@ -87,5 +92,13 @@ public class User {
 
     public void deleteComment(Comment comment) {
         this.comments.remove(comment);
+    }
+
+    public void addApplicant(Applicant applicant) {
+        this.applicants.add(applicant);
+    }
+
+    public void deleteApplicant(Applicant applicant) {
+        this.applicants.remove(applicant);
     }
 }

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
@@ -1,0 +1,26 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantInfoResponse {
+
+    private Long userId;
+    private Long applicantId;
+    private String nickName;
+    private LocalDateTime createAt;
+
+    public static ApplicantInfoResponse of(ApplicantListResponse response) {
+        return ApplicantInfoResponse.builder()
+                .userId(response.getUserId())
+                .applicantId(response.getApplicantId())
+                .nickName(response.getNickName())
+                .createAt(response.getCreateAt())
+                .build();
+    }
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
@@ -1,0 +1,20 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+import sideeffect.project.domain.position.PositionType;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantListResponse {
+
+    private Long userId;
+    private Long applicantId;
+    private String nickName;
+    private PositionType positionType;
+    private LocalDateTime createAt;
+
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantPositionResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantPositionResponse.java
@@ -1,0 +1,33 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+import sideeffect.project.domain.position.PositionType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantPositionResponse {
+    private List<ApplicantInfoResponse> applicants;
+    private int size;
+
+    public static Map<PositionType, ApplicantPositionResponse> mapOf(List<ApplicantListResponse> listResponses) {
+        return listResponses.stream()
+                .collect(groupingBy(ApplicantListResponse::getPositionType,
+                        mapping(ApplicantInfoResponse::of, toList())))
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry :: getKey,
+                        entry -> ApplicantPositionResponse.builder()
+                                .applicants(entry.getValue())
+                                .size(entry.getValue().size())
+                                .build()
+                ));
+    }
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantReleaseRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantReleaseRequest.java
@@ -1,0 +1,19 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantReleaseRequest {
+
+    @NotNull
+    private Long recruitBoardId;
+
+    @NotNull
+    private Long applicantId;
+
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantRequest.java
@@ -1,0 +1,19 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+import sideeffect.project.domain.applicant.Applicant;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantRequest {
+
+    private Long recruitBoardId;
+    private Long boardPositionId;
+
+    public Applicant toApplicant() {
+        return Applicant.builder().build();
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantResponse.java
@@ -1,0 +1,23 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.applicant.ApplicantStatus;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantResponse {
+
+    private Long id;
+    private ApplicantStatus status;
+
+    public static ApplicantResponse of(Applicant applicant) {
+        return ApplicantResponse.builder()
+                .id(applicant.getId())
+                .status(applicant.getStatus())
+                .build();
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantUpdateRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantUpdateRequest.java
@@ -1,0 +1,24 @@
+package sideeffect.project.dto.applicant;
+
+import lombok.*;
+import sideeffect.project.domain.applicant.ApplicantStatus;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ApplicantUpdateRequest {
+
+    @NotNull
+    private Long recruitBoardId;
+
+    @NotNull
+    private Long applicantId;
+
+    @NotBlank
+    private ApplicantStatus status;
+
+}

--- a/server/src/main/java/sideeffect/project/dto/recruit/BoardPositionResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/BoardPositionResponse.java
@@ -13,12 +13,14 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class BoardPositionResponse {
 
+    private Long id;
     private PositionType positionType;
     private int targetNumber;
     private int currentNumber;
 
     public static BoardPositionResponse of(BoardPosition boardPosition) {
         return BoardPositionResponse.builder()
+                .id(boardPosition.getId())
                 .positionType(boardPosition.getPosition().getPositionType())
                 .targetNumber(boardPosition.getTargetNumber())
                 .currentNumber(boardPosition.getCurrentNumber())

--- a/server/src/main/java/sideeffect/project/repository/ApplicantRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/ApplicantRepository.java
@@ -1,0 +1,8 @@
+package sideeffect.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sideeffect.project.domain.applicant.Applicant;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+
+}

--- a/server/src/main/java/sideeffect/project/repository/BoardPositionRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/BoardPositionRepository.java
@@ -1,7 +1,24 @@
 package sideeffect.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sideeffect.project.domain.recruit.BoardPosition;
 
+import java.util.Optional;
+
 public interface BoardPositionRepository extends JpaRepository<BoardPosition, Long> {
+
+    @Query("SELECT bp " +
+            "FROM BoardPosition bp " +
+            "INNER JOIN bp.applicants a " +
+            "ON a.id = :applicantId " +
+            "WHERE bp.currentNumber < bp.targetNumber")
+    Optional<BoardPosition> findBoardPositionIfRecruitable(@Param("applicantId") Long applicantId);
+
+    @Query("SELECT bp " +
+            "FROM BoardPosition bp " +
+            "INNER JOIN bp.applicants a " +
+            "ON a.id = :applicantId")
+    Optional<BoardPosition> findByApplicantId(@Param("applicantId") Long applicantId);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
@@ -3,7 +3,11 @@ package sideeffect.project.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import sideeffect.project.domain.applicant.ApplicantStatus;
 import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.dto.applicant.ApplicantListResponse;
+
+import java.util.List;
 
 public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long>, RecruitBoardCustomRepository {
 
@@ -15,4 +19,13 @@ public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long
             "AND a.user.id = :userId")
     boolean  existsApplicantByRecruitBoard(@Param("boardId") Long boardId, @Param("userId") Long userId);
 
+    @Query("SELECT new sideeffect.project.dto.applicant.ApplicantListResponse(a.user.id, a.id, u.nickname, p.positionType, a.createAt) " +
+            "FROM RecruitBoard rb " +
+            "INNER JOIN rb.boardPositions bp " +
+            "ON rb.id = :boardId " +
+            "JOIN bp.position p " +
+            "INNER JOIN bp.applicants a " +
+            "ON a.status = :status " +
+            "JOIN a.user u")
+    List<ApplicantListResponse> getApplicantsByPosition(@Param("boardId") Long boardId, @Param("status") ApplicantStatus status);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
@@ -1,7 +1,18 @@
 package sideeffect.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sideeffect.project.domain.recruit.RecruitBoard;
 
 public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long>, RecruitBoardCustomRepository {
+
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END " +
+            "FROM RecruitBoard rb " +
+            "JOIN rb.boardPositions bp " +
+            "JOIN bp.applicants a " +
+            "WHERE rb.id = :boardId " +
+            "AND a.user.id = :userId")
+    boolean  existsApplicantByRecruitBoard(@Param("boardId") Long boardId, @Param("userId") Long userId);
+
 }

--- a/server/src/main/java/sideeffect/project/service/ApplicantService.java
+++ b/server/src/main/java/sideeffect/project/service/ApplicantService.java
@@ -1,0 +1,61 @@
+package sideeffect.project.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sideeffect.project.common.exception.AuthException;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
+import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.dto.applicant.ApplicantRequest;
+import sideeffect.project.dto.applicant.ApplicantResponse;
+import sideeffect.project.repository.ApplicantRepository;
+import sideeffect.project.repository.BoardPositionRepository;
+import sideeffect.project.repository.RecruitBoardRepository;
+import sideeffect.project.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicantService {
+
+    private final ApplicantRepository applicantRepository;
+    private final RecruitBoardRepository recruitBoardRepository;
+    private final BoardPositionRepository boardPositionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ApplicantResponse register(Long userId, ApplicantRequest request) {
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        RecruitBoard findRecruitBoard = recruitBoardRepository.findById(request.getRecruitBoardId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
+        BoardPosition findBoardPosition = boardPositionRepository.findById(request.getBoardPositionId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOARD_POSITION_NOT_FOUND));
+
+        isOwnedByUser(findRecruitBoard, userId);
+        isDuplicateApplicant(request.getRecruitBoardId(), userId);
+
+        Applicant applicant = request.toApplicant();
+        applicant.associate(findUser, findBoardPosition);
+
+        return ApplicantResponse.of(applicantRepository.save(applicant));
+    }
+
+    private void isDuplicateApplicant(Long recruitBoardId, Long userId) {
+        if(recruitBoardRepository.existsApplicantByRecruitBoard(recruitBoardId, userId)) {
+            throw new AuthException(ErrorCode.APPLICANT_DUPLICATED);
+        }
+    }
+
+    private void isOwnedByUser(RecruitBoard recruitBoard, Long userId) {
+        if(userId.equals(recruitBoard.getUser().getId())) {
+            throw new AuthException(ErrorCode.APPLICANT_SELF_UNAUTHORIZED);
+        }
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/service/ApplicantService.java
+++ b/server/src/main/java/sideeffect/project/service/ApplicantService.java
@@ -18,7 +18,6 @@ import sideeffect.project.dto.applicant.*;
 import sideeffect.project.repository.ApplicantRepository;
 import sideeffect.project.repository.BoardPositionRepository;
 import sideeffect.project.repository.RecruitBoardRepository;
-import sideeffect.project.repository.UserRepository;
 
 import java.util.List;
 import java.util.Map;
@@ -31,22 +30,19 @@ public class ApplicantService {
     private final ApplicantRepository applicantRepository;
     private final RecruitBoardRepository recruitBoardRepository;
     private final BoardPositionRepository boardPositionRepository;
-    private final UserRepository userRepository;
 
     @Transactional
-    public ApplicantResponse register(Long userId, ApplicantRequest request) {
-        User findUser = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    public ApplicantResponse register(User user, ApplicantRequest request) {
         RecruitBoard findRecruitBoard = recruitBoardRepository.findById(request.getRecruitBoardId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
         BoardPosition findBoardPosition = boardPositionRepository.findById(request.getBoardPositionId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOARD_POSITION_NOT_FOUND));
 
-        isOwnedByUser(findRecruitBoard, userId);
-        isDuplicateApplicant(request.getRecruitBoardId(), userId);
+        isOwnedByUser(findRecruitBoard, user.getId());
+        isDuplicateApplicant(request.getRecruitBoardId(), user.getId());
 
         Applicant applicant = request.toApplicant();
-        applicant.associate(findUser, findBoardPosition);
+        applicant.associate(user, findBoardPosition);
 
         return ApplicantResponse.of(applicantRepository.save(applicant));
     }

--- a/server/src/test/java/sideeffect/project/controller/ApplicantControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/ApplicantControllerTest.java
@@ -1,0 +1,344 @@
+package sideeffect.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import sideeffect.project.common.exception.AuthException;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
+import sideeffect.project.common.exception.InvalidValueException;
+import sideeffect.project.common.security.WithCustomUser;
+import sideeffect.project.config.WebSecurityConfig;
+import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.applicant.ApplicantStatus;
+import sideeffect.project.domain.position.PositionType;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.recruit.ProgressType;
+import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.domain.recruit.RecruitBoardType;
+import sideeffect.project.dto.applicant.*;
+import sideeffect.project.security.UserDetailsServiceImpl;
+import sideeffect.project.service.ApplicantService;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(WebSecurityConfig.class)
+@ComponentScan(basePackages = "sideeffect.project.security")
+@WebMvcTest(ApplicantController.class)
+class ApplicantControllerTest {
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @MockBean
+    private ApplicantService applicantService;
+
+    private MockMvc mvc;
+    private RecruitBoard recruitBoard;
+    private BoardPosition boardPosition;
+    private Applicant applicant;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context) {
+        mvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        applicant = Applicant.builder()
+                .id(1L)
+                .build();
+
+        recruitBoard = RecruitBoard.builder()
+                .id(1L)
+                .title("모집 게시판")
+                .contents("모집합니다.")
+                .recruitBoardType(RecruitBoardType.PROJECT)
+                .progressType(ProgressType.ONLINE)
+                .deadline(LocalDateTime.now())
+                .expectedPeriod("3개월")
+                .build();
+
+        boardPosition = BoardPosition.builder()
+                .id(1L)
+                .targetNumber(3)
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @DisplayName("게시판에 지원한다.")
+    @WithCustomUser
+    @Test
+    void registerApplicant() throws Exception {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+        ApplicantResponse applicantResponse = ApplicantResponse.of(applicant);
+
+        given(applicantService.register(any(), any())).willReturn(applicantResponse);
+
+        mvc.perform(post("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("자신의 게시글에는 지원을 할 수 없다.")
+    @WithCustomUser
+    @Test
+    void registerIsOwnedByUser() throws Exception {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+
+        doThrow(new AuthException(ErrorCode.APPLICANT_SELF_UNAUTHORIZED))
+                .when(applicantService).register(any(), any());
+
+        mvc.perform(post("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("동일한 게시글에는 중복 지원을 할 수 없다.")
+    @WithCustomUser
+    @Test
+    void registerIsDuplicateApplicant() throws Exception {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+
+        doThrow(new AuthException(ErrorCode.APPLICANT_DUPLICATED))
+                .when(applicantService).register(any(), any());
+
+        mvc.perform(post("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("모집 게시판의 지원자 리스트를 조회한다.")
+    @WithCustomUser
+    @Test
+    void findApplicants() throws Exception {
+        List<ApplicantListResponse> applicantListResponses = generateApplicantListResponse(List.of(PositionType.FRONTEND, PositionType.BACKEND), 3);
+
+        given(applicantService.findApplicants(any(), any(), any())).willReturn(ApplicantPositionResponse.mapOf(applicantListResponses));
+
+        mvc.perform(get("/api/applicant/list/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("status", String.valueOf(ApplicantStatus.PENDING)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.FRONTEND.applicants.length()").value(3))
+                .andExpect(jsonPath("$.BACKEND.applicants.length()").value(3))
+                .andExpect(jsonPath("$.FRONTEND.size").value(3))
+                .andExpect(jsonPath("$.BACKEND.size").value(3))
+                .andDo(print());
+    }
+
+    @DisplayName("모집 게시판의 지원자 리스트는 글 작성자가 아니라면 조회가 불가능하다.")
+    @WithCustomUser
+    @Test
+    void findApplicantsByNonOwner() throws Exception {
+        doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
+                .when(applicantService).findApplicants(any(), any(),any());
+
+        mvc.perform(get("/api/applicant/list/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("status", String.valueOf(ApplicantStatus.PENDING)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("게시판의 포지션에 지원한 지원자를 승인한다.")
+    @WithCustomUser
+    @Test
+    void approveApplicant() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.APPROVED)
+                .build();
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("게시판의 포지션에 모두 모집이 되었다면 지원자를 승인할 수 없다.")
+    @WithCustomUser
+    @Test
+    void approveApplicantFullPosition() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.APPROVED)
+                .build();
+
+        doThrow(new EntityNotFoundException(ErrorCode.BOARD_POSITION_FULL))
+                .when(applicantService).approveApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @DisplayName("글 작성자가 아니라면 게시판의 포지션에 지원한 지원자를 승인할 수 없다.")
+    @WithCustomUser
+    @Test
+    void approveApplicantByNonOwner() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.APPROVED)
+                .build();
+
+        doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
+                .when(applicantService).approveApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("해당 지원자가 이미 팀원으로 합류가 되어 있다면 승인할 수 없다.")
+    @WithCustomUser
+    @Test
+    void approveApplicantIfExists() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.APPROVED)
+                .build();
+
+        doThrow(new InvalidValueException(ErrorCode.APPLICANT_NOT_EXISTS))
+                .when(applicantService).approveApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @DisplayName("게시판의 포지션에 지원한 지원자를 거절한다.")
+    @WithCustomUser
+    @Test
+    void rejectApplicant() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.REJECTED)
+                .build();
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("글 작성자가 아니라면 게시판의 포지션에 지원한 지원자를 거절할 수 없다.")
+    @WithCustomUser
+    @Test
+    void rejectApplicantByOwner() throws Exception {
+        ApplicantUpdateRequest request = ApplicantUpdateRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .status(ApplicantStatus.REJECTED)
+                .build();
+
+        doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
+                .when(applicantService).rejectApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("게시판의 포지션에 합류한 팀원를 방출한다.")
+    @WithCustomUser
+    @Test
+    void releaseApplicant() throws Exception {
+        ApplicantReleaseRequest request = ApplicantReleaseRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .build();
+
+        mvc.perform(put("/api/applicant/release")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("글 작성자가 아니라면 게시판의 포지션에 합류한 팀원을 방출할 수 없다.")
+    @WithCustomUser
+    @Test
+    void releaseApplicantByNonOwner() throws Exception {
+        ApplicantReleaseRequest request = ApplicantReleaseRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .build();
+
+        doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
+                .when(applicantService).releaseApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant/release")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("해당 지원자가 팀원으로 합류가 되어 있지 않다면 방출할 수 없다.")
+    @WithCustomUser
+    @Test
+    void releaseApplicantNotExists() throws Exception {
+        ApplicantReleaseRequest request = ApplicantReleaseRequest.builder()
+                .recruitBoardId(recruitBoard.getId())
+                .applicantId(applicant.getId())
+                .build();
+
+        doThrow(new InvalidValueException(ErrorCode.APPLICANT_NOT_EXISTS))
+                .when(applicantService).releaseApplicant(any(), any());
+
+        mvc.perform(put("/api/applicant/release")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    private static List<ApplicantListResponse> generateApplicantListResponse(List<PositionType> positionTypes, int size) {
+        List<ApplicantListResponse> applicantListResponses = new ArrayList<>();
+        Long id = 1L;
+        for (PositionType positionType : positionTypes) {
+            for(int i = 0; i < size; i++) {
+                ApplicantListResponse response = ApplicantListResponse.builder().userId(id).applicantId(id).nickName("test" + id).positionType(positionType).build();
+                applicantListResponses.add(response);
+                id++;
+            }
+        }
+
+        return applicantListResponses;
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
@@ -66,7 +66,7 @@ class RecruitBoardControllerTest {
                 .progressType(ProgressType.ONLINE)
                 .deadline(LocalDateTime.now())
                 .expectedPeriod("3개월")
-                .positions(List.of(new BoardPositionResponse(PositionType.BACKEND, 3, 0)))
+                .positions(List.of(new BoardPositionResponse(1L, PositionType.BACKEND, 3, 0)))
                 .stacks(List.of(new BoardStackResponse(StackType.SPRING, StackLevelType.LOW, "url")))
                 .build();
 

--- a/server/src/test/java/sideeffect/project/domain/applicant/ApplicantTest.java
+++ b/server/src/test/java/sideeffect/project/domain/applicant/ApplicantTest.java
@@ -1,0 +1,50 @@
+package sideeffect.project.domain.applicant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ApplicantTest {
+
+    private User user;
+    private BoardPosition boardPosition;
+    private Applicant applicant;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .nickname("tester")
+                .password("1234")
+                .userRoleType(UserRoleType.ROLE_USER)
+                .email("test@naver.com")
+                .build();
+
+        boardPosition = BoardPosition.builder()
+                .id(1L)
+                .targetNumber(3)
+                .build();
+
+        applicant = Applicant.builder()
+                .id(1L)
+                .build();
+    }
+
+    @DisplayName("유저와 게시판 포지션에 연관관계를 맺는다.")
+    @Test
+    void associate() {
+        applicant.associate(user, boardPosition);
+
+        assertAll(
+                () -> assertThat(applicant.getUser()).isEqualTo(user),
+                () -> assertThat(applicant.getBoardPosition()).isEqualTo(boardPosition)
+        );
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/domain/recruit/BoardPositionTest.java
+++ b/server/src/test/java/sideeffect/project/domain/recruit/BoardPositionTest.java
@@ -1,0 +1,34 @@
+package sideeffect.project.domain.recruit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoardPositionTest {
+
+    @DisplayName("포지션의 모집 인원 수를 증가시킨다.")
+    @Test
+    void increaseCurrentNumber() {
+        BoardPosition boardPosition = BoardPosition.builder().id(1L).targetNumber(1).build();
+
+        int before = boardPosition.getCurrentNumber();
+
+        boardPosition.increaseCurrentNumber();
+
+        assertThat(boardPosition.getCurrentNumber()).isEqualTo(before + 1);
+    }
+
+    @DisplayName("포지션의 모집 인원 수를 감소시킨다.")
+    @Test
+    void decreaseCurrentNumber() {
+        BoardPosition boardPosition = BoardPosition.builder().id(1L).targetNumber(1).build();
+        boardPosition.increaseCurrentNumber();
+
+        int before = boardPosition.getCurrentNumber();
+        boardPosition.decreaseCurrentNumber();
+
+        assertThat(boardPosition.getCurrentNumber()).isEqualTo(before - 1);
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/repository/BoardPositionRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/BoardPositionRepositoryTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sideeffect.project.common.jpa.TestDataRepository;
 import sideeffect.project.domain.applicant.Applicant;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.position.PositionType;
@@ -17,8 +17,7 @@ import javax.persistence.EntityManager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DataJpaTest
-class BoardPositionRepositoryTest {
+class BoardPositionRepositoryTest extends TestDataRepository {
 
     @Autowired
     BoardPositionRepository boardPositionRepository;

--- a/server/src/test/java/sideeffect/project/repository/BoardPositionRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/BoardPositionRepositoryTest.java
@@ -1,0 +1,108 @@
+package sideeffect.project.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.position.Position;
+import sideeffect.project.domain.position.PositionType;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+class BoardPositionRepositoryTest {
+
+    @Autowired
+    BoardPositionRepository boardPositionRepository;
+
+    @Autowired
+    PositionRepository positionRepository;
+
+    @Autowired
+    ApplicantRepository applicantRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EntityManager em;
+
+    private Position backEndPosition;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        backEndPosition = Position.builder().positionType(PositionType.BACKEND).build();
+        positionRepository.save(backEndPosition);
+
+        user = User.builder()
+                .nickname("tester")
+                .password("1234")
+                .userRoleType(UserRoleType.ROLE_USER)
+                .email("test@naver.com")
+                .build();
+
+        userRepository.save(user);
+
+        em.clear();
+    }
+
+    @DisplayName("게시판 특정 포지션에 팀원을 모집할 수 있다면 포지션을 반환한다.")
+    @Test
+    void findBoardPositionIfRecruitable() {
+        BoardPosition boardPosition = BoardPosition.builder().position(backEndPosition).targetNumber(1).build();
+        BoardPosition savedBoardPosition = boardPositionRepository.save(boardPosition);
+
+        Applicant applicant = Applicant.builder().build();
+        applicant.associate(user, savedBoardPosition);
+        Applicant savedApplicant = applicantRepository.save(applicant);
+
+        boolean present = boardPositionRepository.findBoardPositionIfRecruitable(savedApplicant.getId()).isPresent();
+
+        assertThat(present).isTrue();
+    }
+
+    @DisplayName("게시판 특정 포지션에 팀원을 모집할 수 없다면 빈 객체를 반환한다.")
+    @Test
+    void findBoardPositionIfNotRecruitable() {
+        BoardPosition boardPosition = BoardPosition.builder().position(backEndPosition).targetNumber(0).build();
+        BoardPosition savedBoardPosition = boardPositionRepository.save(boardPosition);
+
+        Applicant applicant = Applicant.builder().build();
+        applicant.associate(user, savedBoardPosition);
+        Applicant savedApplicant = applicantRepository.save(applicant);
+
+        boolean present = boardPositionRepository.findBoardPositionIfRecruitable(savedApplicant.getId()).isPresent();
+
+        assertThat(present).isFalse();
+    }
+
+    @DisplayName("지원자가 지원한 포지션을 반환한다.")
+    @Test
+    void findByApplicantId() {
+        BoardPosition boardPosition = BoardPosition.builder().position(backEndPosition).targetNumber(1).build();
+        BoardPosition savedBoardPosition = boardPositionRepository.save(boardPosition);
+
+        Applicant applicant = Applicant.builder().build();
+        applicant.associate(user, savedBoardPosition);
+        Applicant savedApplicant = applicantRepository.save(applicant);
+
+        BoardPosition findBoardPosition = boardPositionRepository.findByApplicantId(savedApplicant.getId()).orElse(null);
+
+        assertAll(
+                () -> assertThat(findBoardPosition).isNotNull(),
+                () -> assertThat(findBoardPosition.getPosition()).isEqualTo(backEndPosition),
+                () -> assertThat(findBoardPosition.getApplicants()).containsExactly(savedApplicant)
+        );
+
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
@@ -66,7 +66,6 @@ class RecruitBoardRepositoryTest {
         stackRepository.save(javaStack);
 
         user = User.builder()
-                .id(1L)
                 .nickname("tester")
                 .password("1234")
                 .userRoleType(UserRoleType.ROLE_USER)
@@ -314,6 +313,34 @@ class RecruitBoardRepositoryTest {
         applicantRepository.save(applicant2);
 
         List<ApplicantListResponse> applicantListResponses = recruitBoardRepository.getApplicantsByPosition(savedBoard.getId(), ApplicantStatus.PENDING);
+
+        assertAll(
+                () -> assertThat(applicantListResponses).hasSize(2)
+        );
+    }
+
+    @DisplayName("게시판에 모집된 지원자의 목록을 조회한다.")
+    @Test
+    void getApplicantsByPositionApproved() {
+        RecruitBoard recruitBoard = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        BoardPosition boardPositionBack = BoardPosition.builder().position(backEndPosition).targetNumber(3).build();
+        BoardPosition boardPositionFront = BoardPosition.builder().position(frontEndPosition).targetNumber(3).build();
+        recruitBoard.addBoardPosition(boardPositionBack);
+        recruitBoard.addBoardPosition(boardPositionFront);
+        RecruitBoard savedBoard = recruitBoardRepository.save(recruitBoard);
+
+        Applicant applicant1 = Applicant.builder().build();
+        applicant1.associate(user, boardPositionBack);
+        applicantRepository.save(applicant1);
+
+        Applicant applicant2 = Applicant.builder().build();
+        applicant2.associate(user, boardPositionFront);
+        applicantRepository.save(applicant2);
+
+        applicant1.updateStatus(ApplicantStatus.APPROVED);
+        applicant2.updateStatus(ApplicantStatus.APPROVED);
+
+        List<ApplicantListResponse> applicantListResponses = recruitBoardRepository.getApplicantsByPosition(savedBoard.getId(), ApplicantStatus.APPROVED);
 
         assertAll(
                 () -> assertThat(applicantListResponses).hasSize(2)

--- a/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Pageable;
 import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.applicant.ApplicantStatus;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.position.PositionType;
 import sideeffect.project.domain.recruit.BoardPosition;
@@ -14,6 +15,7 @@ import sideeffect.project.domain.stack.Stack;
 import sideeffect.project.domain.stack.StackType;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
+import sideeffect.project.dto.applicant.ApplicantListResponse;
 
 import javax.persistence.EntityManager;
 import java.util.ArrayList;
@@ -290,6 +292,31 @@ class RecruitBoardRepositoryTest {
         assertAll(
                 () -> assertThat(first).isFalse(),
                 () -> assertThat(second).isTrue()
+        );
+    }
+
+    @DisplayName("게시판에 지원한 사용자의 목록을 조회한다.")
+    @Test
+    void getApplicantsByPosition() {
+        RecruitBoard recruitBoard = RecruitBoard.builder().title("모집 게시판").contents("내용").build();
+        BoardPosition boardPositionBack = BoardPosition.builder().position(backEndPosition).targetNumber(3).build();
+        BoardPosition boardPositionFront = BoardPosition.builder().position(frontEndPosition).targetNumber(3).build();
+        recruitBoard.addBoardPosition(boardPositionBack);
+        recruitBoard.addBoardPosition(boardPositionFront);
+        RecruitBoard savedBoard = recruitBoardRepository.save(recruitBoard);
+
+        Applicant applicant1 = Applicant.builder().build();
+        applicant1.associate(user, boardPositionBack);
+        applicantRepository.save(applicant1);
+
+        Applicant applicant2 = Applicant.builder().build();
+        applicant2.associate(user, boardPositionFront);
+        applicantRepository.save(applicant2);
+
+        List<ApplicantListResponse> applicantListResponses = recruitBoardRepository.getApplicantsByPosition(savedBoard.getId(), ApplicantStatus.PENDING);
+
+        assertAll(
+                () -> assertThat(applicantListResponses).hasSize(2)
         );
     }
 

--- a/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
@@ -1,0 +1,136 @@
+package sideeffect.project.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sideeffect.project.common.exception.AuthException;
+import sideeffect.project.domain.applicant.Applicant;
+import sideeffect.project.domain.recruit.BoardPosition;
+import sideeffect.project.domain.recruit.ProgressType;
+import sideeffect.project.domain.recruit.RecruitBoard;
+import sideeffect.project.domain.recruit.RecruitBoardType;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+import sideeffect.project.dto.applicant.ApplicantRequest;
+import sideeffect.project.repository.ApplicantRepository;
+import sideeffect.project.repository.BoardPositionRepository;
+import sideeffect.project.repository.RecruitBoardRepository;
+import sideeffect.project.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantServiceTest {
+
+    @InjectMocks
+    private ApplicantService applicantService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RecruitBoardRepository recruitBoardRepository;
+
+    @Mock
+    private BoardPositionRepository boardPositionRepository;
+
+    @Mock
+    private ApplicantRepository applicantRepository;
+
+    private User user;
+    private RecruitBoard recruitBoard;
+    private BoardPosition boardPosition;
+    private Applicant applicant;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .nickname("tester")
+                .password("1234")
+                .userRoleType(UserRoleType.ROLE_USER)
+                .email("test@naver.com")
+                .build();
+
+        recruitBoard = RecruitBoard.builder()
+                .id(1L)
+                .title("모집 게시판")
+                .contents("모집합니다.")
+                .recruitBoardType(RecruitBoardType.PROJECT)
+                .progressType(ProgressType.ONLINE)
+                .deadline(LocalDateTime.now())
+                .expectedPeriod("3개월")
+                .build();
+
+        recruitBoard.associateUser(user);
+
+        boardPosition = BoardPosition.builder()
+                .id(1L)
+                .targetNumber(3)
+                .build();
+
+        applicant = Applicant.builder()
+                .id(1L)
+                .build();
+    }
+
+    @DisplayName("모집 게시판의 포지션에 지원한다.")
+    @Test
+    void registerApplicant() {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+        User otherUser = User.builder().id(2L).nickname("test2").email("test2@naver.com").build();
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
+        when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
+        when(recruitBoardRepository.existsApplicantByRecruitBoard(any(), any())).thenReturn(false);
+        when(applicantRepository.save(any())).thenReturn(applicant);
+
+        applicantService.register(otherUser.getId(), request);
+
+        assertAll(
+                () -> verify(userRepository).findById(any()),
+                () -> verify(boardPositionRepository).findById(any()),
+                () -> verify(applicantRepository).save(any())
+        );
+    }
+
+    @DisplayName("게시판의 주인은 자신의 글에 지원할 수 없다.")
+    @Test
+    void registerIsOwnedByUser() {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
+        when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
+
+        assertThatThrownBy(() -> applicantService.register(recruitBoard.getUser().getId(), request))
+                .isInstanceOf(AuthException.class);
+    }
+
+
+    @DisplayName("하나의 게시판에 중복 지원은 할 수 없다.")
+    @Test
+    void registerIsDuplicateApplicant() {
+        ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
+        User otherUser = User.builder().id(2L).nickname("test2").email("test2@naver.com").build();
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
+        when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
+        when(recruitBoardRepository.existsApplicantByRecruitBoard(any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> applicantService.register(otherUser.getId(), request))
+                .isInstanceOf(AuthException.class);
+    }
+
+}

--- a/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
@@ -26,7 +26,6 @@ import sideeffect.project.dto.applicant.*;
 import sideeffect.project.repository.ApplicantRepository;
 import sideeffect.project.repository.BoardPositionRepository;
 import sideeffect.project.repository.RecruitBoardRepository;
-import sideeffect.project.repository.UserRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -36,7 +35,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.*;
 
@@ -45,9 +45,6 @@ class ApplicantServiceTest {
 
     @InjectMocks
     private ApplicantService applicantService;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private RecruitBoardRepository recruitBoardRepository;
@@ -101,16 +98,14 @@ class ApplicantServiceTest {
         ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
         User otherUser = User.builder().id(2L).nickname("test2").email("test2@naver.com").build();
 
-        when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
         when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
         when(recruitBoardRepository.existsApplicantByRecruitBoard(any(), any())).thenReturn(false);
         when(applicantRepository.save(any())).thenReturn(applicant);
 
-        applicantService.register(otherUser.getId(), request);
+        applicantService.register(otherUser, request);
 
         assertAll(
-                () -> verify(userRepository).findById(any()),
                 () -> verify(boardPositionRepository).findById(any()),
                 () -> verify(applicantRepository).save(any())
         );
@@ -121,11 +116,10 @@ class ApplicantServiceTest {
     void registerIsOwnedByUser() {
         ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
 
-        when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
         when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
 
-        assertThatThrownBy(() -> applicantService.register(recruitBoard.getUser().getId(), request))
+        assertThatThrownBy(() -> applicantService.register(recruitBoard.getUser(), request))
                 .isInstanceOf(AuthException.class);
     }
 
@@ -136,12 +130,11 @@ class ApplicantServiceTest {
         ApplicantRequest request = ApplicantRequest.builder().recruitBoardId(recruitBoard.getId()).boardPositionId(boardPosition.getId()).build();
         User otherUser = User.builder().id(2L).nickname("test2").email("test2@naver.com").build();
 
-        when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
         when(boardPositionRepository.findById(any())).thenReturn(Optional.of(boardPosition));
         when(recruitBoardRepository.existsApplicantByRecruitBoard(any(), any())).thenReturn(true);
 
-        assertThatThrownBy(() -> applicantService.register(otherUser.getId(), request))
+        assertThatThrownBy(() -> applicantService.register(otherUser, request))
                 .isInstanceOf(AuthException.class);
     }
 


### PR DESCRIPTION
다음의 기능을 구현했습니다.  

- 모집 게시판의 포지션에 지원하는 기능 구현
- 글 작성자(팀장)인 경우 지원자 또는 팀원 리스트 조회 구현
- 글 작성자(팀장)인 경우 지원자 거절 또는 수락 기능 구현
- 글 작성자(팀장)인 경우 팀원 방출 기능 구현