### PR TITLE
Feat/applicant 모집 게시글 포지션 지원기능 API 수정

### DIFF
--- a/server/src/main/java/sideeffect/project/common/converter/ApplicantStatusRequestConverter.java
+++ b/server/src/main/java/sideeffect/project/common/converter/ApplicantStatusRequestConverter.java
@@ -1,0 +1,14 @@
+package sideeffect.project.common.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import sideeffect.project.domain.applicant.ApplicantStatus;
+
+@Component
+public class ApplicantStatusRequestConverter implements Converter<String, ApplicantStatus> {
+
+    @Override
+    public ApplicantStatus convert(String source) {
+        return ApplicantStatus.of(source);
+    }
+}

--- a/server/src/main/java/sideeffect/project/config/WebMvcConfig.java
+++ b/server/src/main/java/sideeffect/project/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sideeffect.project.common.converter.ApplicantStatusRequestConverter;
 import sideeffect.project.common.converter.StackTypeRequestConverter;
 
 @Configuration
@@ -20,5 +21,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new StackTypeRequestConverter());
+        registry.addConverter(new ApplicantStatusRequestConverter());
     }
 }

--- a/server/src/main/java/sideeffect/project/controller/ApplicantController.java
+++ b/server/src/main/java/sideeffect/project/controller/ApplicantController.java
@@ -10,6 +10,7 @@ import sideeffect.project.dto.applicant.*;
 import sideeffect.project.security.LoginUser;
 import sideeffect.project.service.ApplicantService;
 
+import javax.validation.Valid;
 import java.util.Map;
 
 @RestController
@@ -21,7 +22,7 @@ public class ApplicantController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PostMapping
-    public ApplicantResponse registerApplicant(@LoginUser User user, @RequestBody ApplicantRequest request) {
+    public ApplicantResponse registerApplicant(@LoginUser User user,@Valid @RequestBody ApplicantRequest request) {
         return applicantService.register(user, request);
     }
 
@@ -37,7 +38,7 @@ public class ApplicantController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PutMapping
-    public void updateApplicant(@LoginUser User user, @RequestBody ApplicantUpdateRequest request) {
+    public void updateApplicant(@LoginUser User user, @Valid @RequestBody ApplicantUpdateRequest request) {
         if(request.getStatus().equals(ApplicantStatus.APPROVED)) {
             applicantService.approveApplicant(user.getId(), request);
         }else if(request.getStatus().equals(ApplicantStatus.REJECTED)) {
@@ -47,7 +48,7 @@ public class ApplicantController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PutMapping("/release")
-    public void releaseApplicant(@LoginUser User user, @RequestBody ApplicantReleaseRequest request) {
+    public void releaseApplicant(@LoginUser User user, @Valid @RequestBody ApplicantReleaseRequest request) {
         applicantService.releaseApplicant(user.getId(), request);
     }
 

--- a/server/src/main/java/sideeffect/project/controller/ApplicantController.java
+++ b/server/src/main/java/sideeffect/project/controller/ApplicantController.java
@@ -22,7 +22,7 @@ public class ApplicantController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @PostMapping
-    public ApplicantResponse registerApplicant(@LoginUser User user,@Valid @RequestBody ApplicantRequest request) {
+    public ApplicantResponse registerApplicant(@LoginUser User user, @Valid @RequestBody ApplicantRequest request) {
         return applicantService.register(user, request);
     }
 

--- a/server/src/main/java/sideeffect/project/controller/ApplicantController.java
+++ b/server/src/main/java/sideeffect/project/controller/ApplicantController.java
@@ -37,7 +37,7 @@ public class ApplicantController {
     }
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
-    @PutMapping
+    @PatchMapping
     public void updateApplicant(@LoginUser User user, @Valid @RequestBody ApplicantUpdateRequest request) {
         if(request.getStatus().equals(ApplicantStatus.APPROVED)) {
             applicantService.approveApplicant(user.getId(), request);
@@ -47,7 +47,7 @@ public class ApplicantController {
     }
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
-    @PutMapping("/release")
+    @PatchMapping("/release")
     public void releaseApplicant(@LoginUser User user, @Valid @RequestBody ApplicantReleaseRequest request) {
         applicantService.releaseApplicant(user.getId(), request);
     }

--- a/server/src/main/java/sideeffect/project/domain/applicant/ApplicantStatus.java
+++ b/server/src/main/java/sideeffect/project/domain/applicant/ApplicantStatus.java
@@ -1,5 +1,34 @@
 package sideeffect.project.domain.applicant;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.stream.Stream;
+
 public enum ApplicantStatus {
-    PENDING, APPROVED, REJECTED
+    PENDING("pending"), APPROVED("approved"), REJECTED("rejected");
+
+    private final String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    ApplicantStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ApplicantStatus parsing(String value) {
+        return Stream.of(ApplicantStatus.values())
+                .filter(applicantStatus -> applicantStatus.getValue().equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static ApplicantStatus of(String value) {
+        return Stream.of(ApplicantStatus.values())
+                .filter(applicantStatus -> applicantStatus.getValue().equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
@@ -13,14 +13,16 @@ public class ApplicantInfoResponse {
     private Long userId;
     private Long applicantId;
     private String nickName;
-    private LocalDateTime createAt;
+    private String email;
+    private LocalDateTime createdAt;
 
     public static ApplicantInfoResponse of(ApplicantListResponse response) {
         return ApplicantInfoResponse.builder()
                 .userId(response.getUserId())
                 .applicantId(response.getApplicantId())
                 .nickName(response.getNickName())
-                .createAt(response.getCreateAt())
+                .email(response.getEmail())
+                .createdAt(response.getCreatedAt())
                 .build();
     }
 }

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
@@ -14,7 +14,8 @@ public class ApplicantListResponse {
     private Long userId;
     private Long applicantId;
     private String nickName;
+    private String email;
     private PositionType positionType;
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
 }

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantRequest.java
@@ -3,13 +3,18 @@ package sideeffect.project.dto.applicant;
 import lombok.*;
 import sideeffect.project.domain.applicant.Applicant;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ApplicantRequest {
 
+    @NotNull
     private Long recruitBoardId;
+
+    @NotNull
     private Long boardPositionId;
 
     public Applicant toApplicant() {

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantUpdateRequest.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantUpdateRequest.java
@@ -3,7 +3,6 @@ package sideeffect.project.dto.applicant;
 import lombok.*;
 import sideeffect.project.domain.applicant.ApplicantStatus;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -18,7 +17,7 @@ public class ApplicantUpdateRequest {
     @NotNull
     private Long applicantId;
 
-    @NotBlank
+    @NotNull
     private ApplicantStatus status;
 
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
@@ -19,7 +19,7 @@ public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long
             "AND a.user.id = :userId")
     boolean  existsApplicantByRecruitBoard(@Param("boardId") Long boardId, @Param("userId") Long userId);
 
-    @Query("SELECT new sideeffect.project.dto.applicant.ApplicantListResponse(a.user.id, a.id, u.nickname, p.positionType, a.createAt) " +
+    @Query("SELECT new sideeffect.project.dto.applicant.ApplicantListResponse(a.user.id, a.id, u.nickname, u.email, p.positionType, a.createAt) " +
             "FROM RecruitBoard rb " +
             "INNER JOIN rb.boardPositions bp " +
             "ON rb.id = :boardId " +

--- a/server/src/main/java/sideeffect/project/service/ApplicantService.java
+++ b/server/src/main/java/sideeffect/project/service/ApplicantService.java
@@ -60,15 +60,14 @@ public class ApplicantService {
 
     @Transactional
     public void approveApplicant(Long userId, ApplicantUpdateRequest applicantUpdateRequest) {
-        BoardPosition findBoardPosition = boardPositionRepository.findBoardPositionIfRecruitable(applicantUpdateRequest.getApplicantId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOARD_POSITION_FULL));
         RecruitBoard findRecruitBoard = recruitBoardRepository.findById(applicantUpdateRequest.getRecruitBoardId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
-
-        validateOwner(findRecruitBoard, userId);
-
         Applicant findApplicant = applicantRepository.findById(applicantUpdateRequest.getApplicantId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLICANT_NOT_FOUND));
+        BoardPosition findBoardPosition = boardPositionRepository.findBoardPositionIfRecruitable(applicantUpdateRequest.getApplicantId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOARD_POSITION_FULL));
+
+        validateOwner(findRecruitBoard, userId);
 
         if(checkIfApplicantIdExists(findRecruitBoard.getId(), findApplicant.getId())) {
             throw new InvalidValueException(ErrorCode.APPLICANT_EXISTS);

--- a/server/src/test/java/sideeffect/project/controller/ApplicantControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/ApplicantControllerTest.java
@@ -168,7 +168,7 @@ class ApplicantControllerTest {
                 .status(ApplicantStatus.APPROVED)
                 .build();
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -188,7 +188,7 @@ class ApplicantControllerTest {
         doThrow(new EntityNotFoundException(ErrorCode.BOARD_POSITION_FULL))
                 .when(applicantService).approveApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict());
@@ -207,7 +207,7 @@ class ApplicantControllerTest {
         doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
                 .when(applicantService).approveApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden());
@@ -226,7 +226,7 @@ class ApplicantControllerTest {
         doThrow(new InvalidValueException(ErrorCode.APPLICANT_NOT_EXISTS))
                 .when(applicantService).approveApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict());
@@ -242,7 +242,7 @@ class ApplicantControllerTest {
                 .status(ApplicantStatus.REJECTED)
                 .build();
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -262,7 +262,7 @@ class ApplicantControllerTest {
         doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
                 .when(applicantService).rejectApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant")
+        mvc.perform(patch("/api/applicant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden());
@@ -277,7 +277,7 @@ class ApplicantControllerTest {
                 .applicantId(applicant.getId())
                 .build();
 
-        mvc.perform(put("/api/applicant/release")
+        mvc.perform(patch("/api/applicant/release")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -296,7 +296,7 @@ class ApplicantControllerTest {
         doThrow(new AuthException(ErrorCode.APPLICANT_UNAUTHORIZED))
                 .when(applicantService).releaseApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant/release")
+        mvc.perform(patch("/api/applicant/release")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden());
@@ -314,7 +314,7 @@ class ApplicantControllerTest {
         doThrow(new InvalidValueException(ErrorCode.APPLICANT_NOT_EXISTS))
                 .when(applicantService).releaseApplicant(any(), any());
 
-        mvc.perform(put("/api/applicant/release")
+        mvc.perform(patch("/api/applicant/release")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict());

--- a/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/ApplicantServiceTest.java
@@ -189,6 +189,8 @@ class ApplicantServiceTest {
     void approveApplicantFullPosition() {
         ApplicantUpdateRequest request = ApplicantUpdateRequest.builder().recruitBoardId(recruitBoard.getId()).applicantId(applicant.getId()).status(ApplicantStatus.APPROVED).build();
 
+        when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
+        when(applicantRepository.findById(any())).thenReturn(Optional.of(applicant));
         when(boardPositionRepository.findBoardPositionIfRecruitable(any())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> applicantService.approveApplicant(user.getId(), request))
@@ -200,8 +202,9 @@ class ApplicantServiceTest {
     void approveApplicantByNonOwner() {
         ApplicantUpdateRequest request = ApplicantUpdateRequest.builder().recruitBoardId(recruitBoard.getId()).applicantId(applicant.getId()).status(ApplicantStatus.APPROVED).build();
 
-        when(boardPositionRepository.findBoardPositionIfRecruitable(any())).thenReturn(Optional.of(boardPosition));
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
+        when(applicantRepository.findById(any())).thenReturn(Optional.of(applicant));
+        when(boardPositionRepository.findBoardPositionIfRecruitable(any())).thenReturn(Optional.of(boardPosition));
 
         Long nonOwner = 2L;
 


### PR DESCRIPTION
다음의 기능을 구현 및 수정했습니다.

- ApplicantStatus enum Type 소문자 형태의 요청과 응답 처리
- DTO 필드 수정 및 Bean Validation 추가
- 지원자 수락 API에 존재하지 않는 지원자ID를 보내는 경우 다른 예외를 반환하는 문제 해결