### PR TITLE
refactor: 모집 게시판 이미지 업로드 구조 수정

### DIFF
--- a/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
@@ -56,13 +56,18 @@ public class RecruitBoardController {
     }
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
-    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping("/image/{id}")
+    public void uploadImage(@LoginUser User user, @PathVariable("id") Long boardId, @ValidImageFile @RequestParam("file") MultipartFile file) {
+        recruitBoardService.uploadImage(user.getId(), boardId, file);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PostMapping
     public RecruitBoardResponse registerRecruitBoard(
             @LoginUser User user,
-            @Valid @RequestPart RecruitBoardRequest request,
-            @ValidImageFile @RequestPart MultipartFile imgFile
+            @Valid @RequestBody RecruitBoardRequest request
             ) {
-        return recruitBoardService.register(user, request, imgFile);
+        return recruitBoardService.register(user, request);
     }
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
@@ -70,10 +75,9 @@ public class RecruitBoardController {
     public void updateRecruitBoard(
             @LoginUser User user,
             @PathVariable("id") Long boardId,
-            @Valid @RequestPart RecruitBoardUpdateRequest request,
-            @ValidImageFile @RequestPart MultipartFile imgFile
+            @Valid @RequestBody RecruitBoardUpdateRequest request
     ) {
-        recruitBoardService.updateRecruitBoard(user.getId(), boardId, request, imgFile);
+        recruitBoardService.updateRecruitBoard(user.getId(), boardId, request);
     }
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")

--- a/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
@@ -32,12 +32,12 @@ public class RecruitBoardService {
     private final RecruitUploadService recruitUploadService;
 
     @Transactional
-    public RecruitBoardResponse register(User user, RecruitBoardRequest request, MultipartFile imgFile) {
+    public RecruitBoardResponse register(User user, RecruitBoardRequest request) {
         RecruitBoard recruitBoard = request.toRecruitBoard();
         recruitBoard.associateUser(user);
         recruitBoard.updateBoardPositions(getBoardPositions(recruitBoard, request.getPositions()));
         recruitBoard.updateBoardStacks(getBoardStacks(recruitBoard, request.getTags()));
-        saveImageFile(imgFile, recruitBoard);
+        saveImageFile(null, recruitBoard); //기본 이미지 사용
 
         return RecruitBoardResponse.of(recruitBoardRepository.save(recruitBoard));
     }
@@ -66,14 +66,21 @@ public class RecruitBoardService {
     }
 
     @Transactional
-    public void updateRecruitBoard(Long userId, Long boardId, RecruitBoardUpdateRequest request, MultipartFile imgFile) {
+    public void updateRecruitBoard(Long userId, Long boardId, RecruitBoardUpdateRequest request) {
         RecruitBoard findRecruitBoard = recruitBoardRepository.findById(boardId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
         validateOwner(userId, findRecruitBoard);
         findRecruitBoard.updateBoardStacks(getBoardStacks(findRecruitBoard, request.getTags()));
-        saveImageFile(imgFile, findRecruitBoard);
 
         findRecruitBoard.update(request.toRecruitBoard());
+    }
+
+    @Transactional
+    public void uploadImage(Long userId, Long boardId, MultipartFile file) {
+        RecruitBoard findRecruitBoard = recruitBoardRepository.findById(boardId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
+        validateOwner(userId, findRecruitBoard);
+        saveImageFile(file, findRecruitBoard);
     }
 
     @Transactional

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 import sideeffect.project.common.exception.AuthException;
 import sideeffect.project.common.exception.InvalidValueException;
 import sideeffect.project.common.fileupload.service.RecruitUploadService;
@@ -92,7 +91,6 @@ class RecruitBoardServiceTest {
     @Test
     void register() throws IOException {
         String imgPath = "/test/test.png";
-        MockMultipartFile file = new MockMultipartFile("image", "test".getBytes());
         RecruitBoardRequest request = RecruitBoardRequest.builder()
                 .title("모집 게시판 제목")
                 .content("모집합니다.")
@@ -107,7 +105,7 @@ class RecruitBoardServiceTest {
         when(stackService.findByStackType(any())).thenReturn(stack);
         when(recruitUploadService.storeFile(any())).thenReturn(imgPath);
 
-        recruitBoardService.register(user, request, file);
+        recruitBoardService.register(user, request);
 
         assertAll(
                 () -> verify(recruitBoardRepository).save(any()),
@@ -150,7 +148,6 @@ class RecruitBoardServiceTest {
     @Test
     public void updateRecruitBoard() throws IOException {
         String imgPath = "/test/test.png";
-        MockMultipartFile file = new MockMultipartFile("image", "test".getBytes());
         RecruitBoardUpdateRequest request = RecruitBoardUpdateRequest.builder()
                 .title("수정된 제목")
                 .content("수정된 내용")
@@ -164,13 +161,11 @@ class RecruitBoardServiceTest {
         Long userId = 1L;
 
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
-        when(recruitUploadService.storeFile(any())).thenReturn(imgPath);
 
-        recruitBoardService.updateRecruitBoard(userId, boardId, request, file);
+        recruitBoardService.updateRecruitBoard(userId, boardId, request);
 
         assertAll(
                 () -> verify(recruitBoardRepository).findById(any()),
-                () -> verify(recruitUploadService).storeFile(any()),
                 () -> assertThat(recruitBoard.getTitle()).isEqualTo(request.getTitle()),
                 () -> assertThat(recruitBoard.getContents()).isEqualTo(request.getContent()),
                 () -> assertThat(recruitBoard.getBoardPositions()).hasSize(0),
@@ -181,7 +176,6 @@ class RecruitBoardServiceTest {
     @DisplayName("모집 게시판 주인이 아닌자가 업데이트 시도 시 예외 발생")
     @Test
     void updateByNonOwner() {
-        MockMultipartFile file = new MockMultipartFile("image", "test".getBytes());
         RecruitBoardUpdateRequest request = RecruitBoardUpdateRequest.builder()
                 .title("모집 게시판 제목")
                 .content("모집합니다.")
@@ -193,7 +187,7 @@ class RecruitBoardServiceTest {
 
         when(recruitBoardRepository.findById(any())).thenReturn(Optional.of(recruitBoard));
 
-        assertThatThrownBy(() -> recruitBoardService.updateRecruitBoard(nonOwnerId, boardId, request, file))
+        assertThatThrownBy(() -> recruitBoardService.updateRecruitBoard(nonOwnerId, boardId, request))
                 .isInstanceOf(AuthException.class);
     }
 


### PR DESCRIPTION
다음의 기능을 수정했습니다.  

- 모집 게시판 저장 시 JSON데이터와 파일 동시에 받아 업로드 하는 구조를 분리
- 모집 게시판 수정 시 JSON데이터와 파일 동시에 받아 업로드 하는 구조를 분리
- 모집 게시판 이미지 업로드 API 기능 구현