### PR TITLE
Feat/recruit board 모집게시판 좋아요 여부 로직 추가 및 무한 스크롤 쿼리 개선

### DIFF
--- a/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
@@ -32,8 +32,8 @@ public class RecruitBoardController {
     private final RecruitLikeService recruitLikeService;
 
     @GetMapping("/{id}")
-    public RecruitBoardResponse findRecruitBoard(@PathVariable Long id) {
-        return recruitBoardService.findRecruitBoard(id);
+    public RecruitBoardResponse findRecruitBoard(@PathVariable Long id, @LoginUser User user) {
+        return recruitBoardService.findRecruitBoard(id, user);
     }
 
     @GetMapping("/all")

--- a/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
@@ -37,8 +37,8 @@ public class RecruitBoardController {
     }
 
     @GetMapping("/all")
-    public RecruitBoardAllResponse findAllRecruitBoard() {
-        return recruitBoardService.findAllRecruitBoard();
+    public RecruitBoardAllResponse findAllRecruitBoard(@LoginUser User user) {
+        return recruitBoardService.findAllRecruitBoard(user);
     }
 
     @GetMapping("/scroll")

--- a/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
+++ b/server/src/main/java/sideeffect/project/controller/RecruitBoardController.java
@@ -42,8 +42,8 @@ public class RecruitBoardController {
     }
 
     @GetMapping("/scroll")
-    public RecruitBoardScrollResponse findScrollRecruitBoard(@ModelAttribute RecruitBoardScrollRequest request) {
-        return recruitBoardService.findRecruitBoards(request);
+    public RecruitBoardScrollResponse findScrollRecruitBoard(@Valid @ModelAttribute RecruitBoardScrollRequest request, @LoginUser User user) {
+        return recruitBoardService.findRecruitBoards(request, user);
     }
 
     @GetMapping(value = "/image/{filename}", produces = MediaType.IMAGE_JPEG_VALUE)

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardAndLikeDto.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardAndLikeDto.java
@@ -1,0 +1,13 @@
+package sideeffect.project.dto.recruit;
+
+import lombok.*;
+import sideeffect.project.domain.recruit.RecruitBoard;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class RecruitBoardAndLikeDto {
+    private RecruitBoard recruitBoard;
+    private boolean like;
+}

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
@@ -21,6 +21,7 @@ public class RecruitBoardResponse {
     private String content;
     private String imgSrc;
     private int views;
+    private boolean like;
     private int likeNum;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
@@ -43,9 +44,32 @@ public class RecruitBoardResponse {
                 .build();
     }
 
+    public static RecruitBoardResponse ofLike(RecruitBoardAndLikeDto recruitBoardAndLikeDto) {
+        return RecruitBoardResponse.builder()
+                .id(recruitBoardAndLikeDto.getRecruitBoard().getId())
+                .userId(recruitBoardAndLikeDto.getRecruitBoard().getUser().getId())
+                .projectName(recruitBoardAndLikeDto.getRecruitBoard().getProjectName())
+                .title(recruitBoardAndLikeDto.getRecruitBoard().getTitle())
+                .content(recruitBoardAndLikeDto.getRecruitBoard().getContents())
+                .imgSrc(recruitBoardAndLikeDto.getRecruitBoard().getImgSrc())
+                .views(recruitBoardAndLikeDto.getRecruitBoard().getViews())
+                .like(recruitBoardAndLikeDto.isLike())
+                .likeNum(recruitBoardAndLikeDto.getRecruitBoard().getRecruitLikes().size())
+                .createdAt(recruitBoardAndLikeDto.getRecruitBoard().getCreateAt())
+                .positions(BoardPositionResponse.listOf(recruitBoardAndLikeDto.getRecruitBoard().getBoardPositions()))
+                .tags(BoardStackResponse.listOf(recruitBoardAndLikeDto.getRecruitBoard().getBoardStacks()))
+                .build();
+    }
+
     public static List<RecruitBoardResponse> listOf(List<RecruitBoard> recruitBoards) {
         return recruitBoards.stream()
                 .map(RecruitBoardResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public static List<RecruitBoardResponse> listOfLike(List<RecruitBoardAndLikeDto> recruitBoards) {
+        return recruitBoards.stream()
+                .map(RecruitBoardResponse::ofLike)
                 .collect(Collectors.toList());
     }
 

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
@@ -12,5 +12,6 @@ public interface RecruitBoardCustomRepository {
 
     Optional<RecruitBoardAndLikeDto> findByBoardIdAndUserId(Long boardId, Long userId);
 
+    List<RecruitBoardAndLikeDto> findByAllWithLike(Long userId);
     boolean existsApplicantByRecruitBoard(Long boardId, Long userId);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
@@ -4,10 +4,13 @@ import sideeffect.project.domain.stack.StackType;
 import sideeffect.project.dto.recruit.RecruitBoardAndLikeDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RecruitBoardCustomRepository {
 
     List<RecruitBoardAndLikeDto> findWithSearchConditions(Long userId, Long lastId, String keyword, List<StackType> stackTypes, Integer size);
+
+    Optional<RecruitBoardAndLikeDto> findByBoardIdAndUserId(Long boardId, Long userId);
 
     boolean existsApplicantByRecruitBoard(Long boardId, Long userId);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepository.java
@@ -1,13 +1,13 @@
 package sideeffect.project.repository;
 
-import org.springframework.data.domain.Pageable;
-import sideeffect.project.domain.recruit.RecruitBoard;
 import sideeffect.project.domain.stack.StackType;
+import sideeffect.project.dto.recruit.RecruitBoardAndLikeDto;
 
 import java.util.List;
 
 public interface RecruitBoardCustomRepository {
-    List<RecruitBoard> findWithSearchConditions(Long lastId, String keyword, List<StackType> stackTypes, Pageable pageable);
+
+    List<RecruitBoardAndLikeDto> findWithSearchConditions(Long userId, Long lastId, String keyword, List<StackType> stackTypes, Integer size);
 
     boolean existsApplicantByRecruitBoard(Long boardId, Long userId);
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
@@ -56,6 +56,13 @@ public class RecruitBoardCustomRepositoryImpl implements RecruitBoardCustomRepos
         return Optional.ofNullable(recruitBoardAndLikeDto);
     }
 
+    @Override
+    public List<RecruitBoardAndLikeDto> findByAllWithLike(Long userId) {
+        return jpaQueryFactory.select(getResponseConstructor(userId))
+                .from(recruitBoard)
+                .fetch();
+    }
+
     private ConstructorExpression<RecruitBoardAndLikeDto> getResponseConstructor(Long userId) {
 
         return Projections.constructor(RecruitBoardAndLikeDto.class,

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
@@ -16,6 +16,7 @@ import sideeffect.project.dto.recruit.RecruitBoardAndLikeDto;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 
 import static org.springframework.util.StringUtils.hasText;
 import static sideeffect.project.domain.applicant.QApplicant.applicant;
@@ -43,6 +44,16 @@ public class RecruitBoardCustomRepositoryImpl implements RecruitBoardCustomRepos
         return query.where(lastIdLt(lastId), addKeywordCondition(keyword), addStackTypeCondition(stackTypes))
                 .orderBy(recruitBoard.id.desc())
                 .limit(size).fetch();
+    }
+
+    @Override
+    public Optional<RecruitBoardAndLikeDto> findByBoardIdAndUserId(Long boardId, Long userId) {
+        RecruitBoardAndLikeDto recruitBoardAndLikeDto = jpaQueryFactory.select(getResponseConstructor(userId))
+                .from(recruitBoard)
+                .where(recruitBoard.id.eq(boardId))
+                .fetchOne();
+
+        return Optional.ofNullable(recruitBoardAndLikeDto);
     }
 
     private ConstructorExpression<RecruitBoardAndLikeDto> getResponseConstructor(Long userId) {

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardCustomRepositoryImpl.java
@@ -1,21 +1,29 @@
 package sideeffect.project.repository;
 
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.util.StringUtils;
-import sideeffect.project.domain.recruit.RecruitBoard;
 import sideeffect.project.domain.stack.StackType;
+import sideeffect.project.dto.recruit.RecruitBoardAndLikeDto;
 
 import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.util.StringUtils.hasText;
 import static sideeffect.project.domain.applicant.QApplicant.applicant;
+import static sideeffect.project.domain.like.QRecruitLike.recruitLike;
 import static sideeffect.project.domain.recruit.QBoardPosition.boardPosition;
+import static sideeffect.project.domain.recruit.QBoardStack.boardStack;
 import static sideeffect.project.domain.recruit.QRecruitBoard.recruitBoard;
+import static sideeffect.project.domain.stack.QStack.stack;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,52 +33,49 @@ public class RecruitBoardCustomRepositoryImpl implements RecruitBoardCustomRepos
     private final EntityManager em;
 
     @Override
-    public List<RecruitBoard> findWithSearchConditions(Long lastId, String keyword, List<StackType> stackTypes, Pageable pageable) {
-
-        String jpql = "select distinct rb from RecruitBoard rb";
-        String joinSql = "";
-        String whereSql = " where ";
-        List<String> whereConditions = new ArrayList<>();
-
-        if(lastId != null) {
-            whereConditions.add("rb.id < :lastId");
-        }
+    public List<RecruitBoardAndLikeDto> findWithSearchConditions(Long userId, Long lastId, String keyword, List<StackType> stackTypes, Integer size) {
+        JPAQuery<RecruitBoardAndLikeDto> query = jpaQueryFactory.selectDistinct(getResponseConstructor(userId)).from(recruitBoard);
 
         if(stackTypes != null && !stackTypes.isEmpty()) {
-            joinSql += " join rb.boardStacks bs";
-            whereConditions.add("bs.stack.stackType in :stackTypes");
+            query.innerJoin(recruitBoard.boardStacks, boardStack).innerJoin(boardStack.stack, stack);
         }
 
-        if(StringUtils.hasText(keyword)) {
-            whereConditions.add("(rb.title like concat('%',:keyword,'%') or rb.contents like concat('%',:keyword,'%'))");
+        return query.where(lastIdLt(lastId), addKeywordCondition(keyword), addStackTypeCondition(stackTypes))
+                .orderBy(recruitBoard.id.desc())
+                .limit(size).fetch();
+    }
+
+    private ConstructorExpression<RecruitBoardAndLikeDto> getResponseConstructor(Long userId) {
+
+        return Projections.constructor(RecruitBoardAndLikeDto.class,
+                recruitBoard,
+                getLikeExpression(userId)
+        );
+    }
+    private Expression<Boolean> getLikeExpression(Long userId) {
+        if (userId == null) {
+            return Expressions.asBoolean(false).isTrue();
+        }
+        return ExpressionUtils.as(JPAExpressions.selectOne()
+                        .from(recruitLike)
+                        .where(recruitLike.user.id.eq(userId).and(recruitLike.recruitBoard.id.eq(recruitBoard.id))).limit(1).isNotNull(),
+                "like");
+    }
+
+    private BooleanExpression lastIdLt(Long lastId) {
+        return lastId != null ? recruitBoard.id.lt(lastId) : null;
+    }
+
+    private BooleanExpression addKeywordCondition(String keyword) {
+        return hasText(keyword) ? recruitBoard.title.containsIgnoreCase(keyword).or(recruitBoard.contents.containsIgnoreCase(keyword)) : null;
+    }
+
+    private BooleanExpression addStackTypeCondition(List<StackType> stackTypes) {
+        if(stackTypes == null || stackTypes.isEmpty()) {
+            return null;
         }
 
-        if(StringUtils.hasText(joinSql)) {
-            jpql += joinSql;
-        }
-
-        if(!whereConditions.isEmpty()) {
-            jpql += whereSql;
-            jpql += String.join(" and ", whereConditions);
-        }
-
-        jpql += " order by rb.id desc";
-
-        TypedQuery<RecruitBoard> query = em.createQuery(jpql, RecruitBoard.class);
-
-        if(lastId != null) {
-            query.setParameter("lastId", lastId);
-        }
-
-        if(stackTypes != null && !stackTypes.isEmpty()) {
-            query.setParameter("stackTypes", stackTypes);
-        }
-
-        if(StringUtils.hasText(keyword)) {
-            query.setParameter("keyword", keyword);
-        }
-
-        return query.setMaxResults(pageable.getPageSize()).getResultList();
+        return boardStack.stack.stackType.in(stackTypes);
     }
 
     @Override

--- a/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
@@ -42,12 +42,12 @@ public class RecruitBoardService {
     }
 
     @Transactional
-    public RecruitBoardResponse findRecruitBoard(Long boardId) {
-        RecruitBoard findRecruitBoard = recruitBoardRepository.findById(boardId)
+    public RecruitBoardResponse findRecruitBoard(Long boardId, User user) {
+        RecruitBoardAndLikeDto findRecruitBoard = recruitBoardRepository.findByBoardIdAndUserId(boardId, user.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
-        findRecruitBoard.increaseViews();
+        findRecruitBoard.getRecruitBoard().increaseViews();
 
-        return RecruitBoardResponse.of(findRecruitBoard);
+        return RecruitBoardResponse.ofLike(findRecruitBoard);
     }
 
     @Transactional(readOnly = true)

--- a/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
@@ -1,7 +1,6 @@
 package sideeffect.project.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,10 +58,10 @@ public class RecruitBoardService {
     }
 
     @Transactional(readOnly = true)
-    public RecruitBoardScrollResponse findRecruitBoards(RecruitBoardScrollRequest request) {
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(request.getLastId(), request.getKeyword(), request.validateStackTypes(), Pageable.ofSize(request.getSize() + 1));
+    public RecruitBoardScrollResponse findRecruitBoards(RecruitBoardScrollRequest request, User user) {
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), request.getLastId(), request.getKeyword(), request.validateStackTypes(), request.getSize() + 1);
         boolean hasNext = hasNextRecruitBoards(findRecruitBoards, request.getSize());
-        return RecruitBoardScrollResponse.of(RecruitBoardResponse.listOf(findRecruitBoards), hasNext);
+        return RecruitBoardScrollResponse.of(RecruitBoardResponse.listOfLike(findRecruitBoards), hasNext);
     }
 
     @Transactional
@@ -150,7 +149,7 @@ public class RecruitBoardService {
         }
     }
 
-    private boolean hasNextRecruitBoards(List<RecruitBoard> recruitBoards, int requestSize) {
+    private boolean hasNextRecruitBoards(List<RecruitBoardAndLikeDto> recruitBoards, int requestSize) {
         boolean hasNext = false;
 
         if(recruitBoards.size() > requestSize) {

--- a/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
@@ -51,10 +51,10 @@ public class RecruitBoardService {
     }
 
     @Transactional(readOnly = true)
-    public RecruitBoardAllResponse findAllRecruitBoard() {
-        List<RecruitBoard> recruitBoards = recruitBoardRepository.findAll();
+    public RecruitBoardAllResponse findAllRecruitBoard(User user) {
+        List<RecruitBoardAndLikeDto> allWithLike = recruitBoardRepository.findByAllWithLike(user.getId());
 
-        return RecruitBoardAllResponse.of(RecruitBoardResponse.listOf(recruitBoards));
+        return RecruitBoardAllResponse.of(RecruitBoardResponse.listOfLike(allWithLike));
     }
 
     @Transactional(readOnly = true)

--- a/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
@@ -67,7 +67,7 @@ class RecruitBoardControllerTest {
     }
 
     @DisplayName("모집게시글을 조회한다.")
-    @WithMockUser
+    @WithCustomUser
     @Test
     void findRecruitBoard() throws Exception {
         RecruitBoardResponse response = RecruitBoardResponse.builder()
@@ -81,7 +81,7 @@ class RecruitBoardControllerTest {
                 .tags(List.of(new BoardStackResponse(StackType.SPRING.getValue(), "url")))
                 .build();
 
-        given(recruitBoardService.findRecruitBoard(any())).willReturn(response);
+        given(recruitBoardService.findRecruitBoard(any(), any())).willReturn(response);
 
         mvc.perform(get("/api/recruit-board/1")
                 .contentType(MediaType.APPLICATION_JSON))
@@ -93,7 +93,7 @@ class RecruitBoardControllerTest {
                 .andExpect(jsonPath("$.tags.length()").value(1))
                 .andDo(print());
 
-        verify(recruitBoardService).findRecruitBoard(any());
+        verify(recruitBoardService).findRecruitBoard(any(), any());
     }
 
     @DisplayName("모집게시글 목록을 조회한다.")

--- a/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
@@ -97,7 +97,7 @@ class RecruitBoardControllerTest {
     }
 
     @DisplayName("모집게시글 목록을 조회한다.")
-    @WithMockUser
+    @WithCustomUser
     @Test
     void findScrollRecruitBoard() throws Exception {
         RecruitBoard recruitBoard1 = RecruitBoard.builder().id(10L).title("모집 게시판1").contents("모집합니다1.").build();
@@ -107,7 +107,7 @@ class RecruitBoardControllerTest {
         List<RecruitBoardResponse> recruitBoardResponses = RecruitBoardResponse.listOf(List.of(recruitBoard1, recruitBoard2));
         RecruitBoardScrollResponse scrollResponse = RecruitBoardScrollResponse.of(recruitBoardResponses, false);
 
-        given(recruitBoardService.findRecruitBoards(any())).willReturn(scrollResponse);
+        given(recruitBoardService.findRecruitBoards(any(), any())).willReturn(scrollResponse);
 
         mvc.perform(get("/api/recruit-board/scroll")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -119,7 +119,7 @@ class RecruitBoardControllerTest {
                 .andExpect(jsonPath("$.hasNext").value(false))
                 .andDo(print());
 
-        verify(recruitBoardService).findRecruitBoards(any());
+        verify(recruitBoardService).findRecruitBoards(any(), any());
     }
 
     @DisplayName("모집게시글 전체를 조회한다.")

--- a/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -123,7 +122,7 @@ class RecruitBoardControllerTest {
     }
 
     @DisplayName("모집게시글 전체를 조회한다.")
-    @WithMockUser
+    @WithCustomUser
     @Test
     void findAllRecruitBoard() throws Exception {
         RecruitBoard recruitBoard1 = RecruitBoard.builder().id(10L).title("모집 게시판1").contents("모집합니다1.").build();
@@ -133,7 +132,7 @@ class RecruitBoardControllerTest {
         List<RecruitBoardResponse> recruitBoardResponses = RecruitBoardResponse.listOf(List.of(recruitBoard1, recruitBoard2));
         RecruitBoardAllResponse response = RecruitBoardAllResponse.of(recruitBoardResponses);
 
-        given(recruitBoardService.findAllRecruitBoard()).willReturn(response);
+        given(recruitBoardService.findAllRecruitBoard(any())).willReturn(response);
 
         mvc.perform(get("/api/recruit-board/all")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -141,7 +140,7 @@ class RecruitBoardControllerTest {
                 .andExpect(jsonPath("$.recruitBoards.length()").value(2))
                 .andDo(print());
 
-        verify(recruitBoardService).findAllRecruitBoard();
+        verify(recruitBoardService).findAllRecruitBoard(any());
     }
 
     @DisplayName("모집 게시판을 등록한다.")

--- a/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
+++ b/server/src/test/java/sideeffect/project/repository/RecruitBoardRepositoryTest.java
@@ -1,11 +1,12 @@
 package sideeffect.project.repository;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
+import sideeffect.project.common.jpa.TestDataRepository;
 import sideeffect.project.domain.applicant.Applicant;
 import sideeffect.project.domain.applicant.ApplicantStatus;
-import sideeffect.project.common.jpa.TestDataRepository;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.position.PositionType;
 import sideeffect.project.domain.recruit.BoardPosition;
@@ -16,6 +17,7 @@ import sideeffect.project.domain.stack.StackType;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
 import sideeffect.project.dto.applicant.ApplicantListResponse;
+import sideeffect.project.dto.recruit.RecruitBoardAndLikeDto;
 
 import javax.persistence.EntityManager;
 import java.util.ArrayList;
@@ -85,8 +87,8 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         List<Long> answerBoardIds = LongStream.rangeClosed(lastId - 29, lastId - 20).sorted().boxed().collect(Collectors.toList());
         Collections.reverse(answerBoardIds);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(lastId - 19, "", null, Pageable.ofSize(10));
-        List<Long> returnBoardIds = findRecruitBoards.stream().map(RecruitBoard::getId).collect(Collectors.toList());
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(),lastId - 19, "", null, 10);
+        List<Long> returnBoardIds = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).map(RecruitBoard::getId).collect(Collectors.toList());
 
         assertAll(
                 () -> assertThat(findRecruitBoards).hasSize(10),
@@ -103,11 +105,12 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         recruitBoardRepository.save(recruitBoardInSearchTitle);
         recruitBoardRepository.save(recruitBoardNotInSearchTitle);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchTitle, null, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(),null, searchTitle, null, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInSearchTitle),
-                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInSearchTitle)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(recruitBoardInSearchTitle),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(recruitBoardNotInSearchTitle)
         );
     }
 
@@ -120,11 +123,12 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         recruitBoardRepository.save(recruitBoardInSearchContents);
         recruitBoardRepository.save(recruitBoardNotInSearchContents);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchContents, null, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), null, searchContents, null, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInSearchContents),
-                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInSearchContents)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(recruitBoardInSearchContents),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(recruitBoardNotInSearchContents)
         );
     }
 
@@ -137,12 +141,13 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         recruitBoardRepository.save(recruitBoard1);
         recruitBoardRepository.save(recruitBoard2);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(recruitBoard2.getId(), searchContents, null, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), recruitBoard2.getId(), searchContents, null, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(recruitBoard1),
-                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoard2),
-                () -> assertThat(findRecruitBoards).hasSize(1)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(recruitBoard1),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(recruitBoard2),
+                () -> assertThat(findRecruitBoardsOfList).hasSize(1)
         );
     }
 
@@ -167,11 +172,12 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         searchStacks.add(StackType.JAVA);
         searchStacks.add(StackType.JAVASCRIPT);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, "", searchStacks, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), null, "", searchStacks, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInJavaScriptStack, recruitBoardInJavaStack),
-                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardNotInStack)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(recruitBoardInJavaScriptStack, recruitBoardInJavaStack),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(recruitBoardNotInStack)
         );
     }
 
@@ -193,12 +199,13 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         searchStacks.add(StackType.JAVA);
         searchStacks.add(StackType.JAVASCRIPT);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(recruitBoardInJavaScriptStack.getId(), "", searchStacks, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), recruitBoardInJavaScriptStack.getId(), "", searchStacks, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(recruitBoardInJavaStack),
-                () -> assertThat(findRecruitBoards).doesNotContain(recruitBoardInJavaScriptStack),
-                () -> assertThat(findRecruitBoards).hasSize(1)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(recruitBoardInJavaStack),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(recruitBoardInJavaScriptStack),
+                () -> assertThat(findRecruitBoardsOfList).hasSize(1)
         );
     }
 
@@ -231,14 +238,15 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         List<StackType> searchStacks = new ArrayList<>();
         searchStacks.add(StackType.JAVA);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(null, searchKeyword, searchStacks, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), null, searchKeyword, searchStacks, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(boardInKeywordWithStacks),
-                () -> assertThat(findRecruitBoards).doesNotContain(boardInKeywordWithOtherStacks),
-                () -> assertThat(findRecruitBoards).doesNotContain(boardInKeyword),
-                () -> assertThat(findRecruitBoards).doesNotContain(boardInStacks),
-                () -> assertThat(findRecruitBoards).doesNotContain(boardNotInKeywordWithStacks)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(boardInKeywordWithStacks),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(boardInKeywordWithOtherStacks),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(boardInKeyword),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(boardInStacks),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(boardNotInKeywordWithStacks)
         );
     }
 
@@ -262,12 +270,13 @@ class RecruitBoardRepositoryTest extends TestDataRepository {
         List<StackType> searchStacks = new ArrayList<>();
         searchStacks.add(StackType.JAVA);
 
-        List<RecruitBoard> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(boardInKeywordWithStacks2.getId(), searchKeyword, searchStacks, Pageable.ofSize(5));
+        List<RecruitBoardAndLikeDto> findRecruitBoards = recruitBoardRepository.findWithSearchConditions(user.getId(), boardInKeywordWithStacks2.getId(), searchKeyword, searchStacks, 5);
+        List<RecruitBoard> findRecruitBoardsOfList = findRecruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
         assertAll(
-                () -> assertThat(findRecruitBoards).containsExactly(boardInKeywordWithStacks1),
-                () -> assertThat(findRecruitBoards).doesNotContain(boardInKeywordWithStacks2),
-                () -> assertThat(findRecruitBoards).hasSize(1)
+                () -> assertThat(findRecruitBoardsOfList).containsExactly(boardInKeywordWithStacks1),
+                () -> assertThat(findRecruitBoardsOfList).doesNotContain(boardInKeywordWithStacks2),
+                () -> assertThat(findRecruitBoardsOfList).hasSize(1)
         );
     }
 

--- a/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
+++ b/server/src/test/java/sideeffect/project/service/RecruitBoardServiceTest.java
@@ -159,14 +159,13 @@ class RecruitBoardServiceTest {
     @Test
     void findAllRecruitBoard() {
         List<RecruitBoardAndLikeDto> recruitBoards = generateRecruitBoards(1L, 100);
-        List<RecruitBoard> findRecruitBoardsOfList = recruitBoards.stream().map(RecruitBoardAndLikeDto::getRecruitBoard).collect(Collectors.toList());
 
-        when(recruitBoardRepository.findAll()).thenReturn(findRecruitBoardsOfList);
+        when(recruitBoardRepository.findByAllWithLike(any())).thenReturn(recruitBoards);
 
-        RecruitBoardAllResponse allRecruitBoard = recruitBoardService.findAllRecruitBoard();
+        RecruitBoardAllResponse allRecruitBoard = recruitBoardService.findAllRecruitBoard(user);
 
         assertAll(
-                () -> verify(recruitBoardRepository).findAll(),
+                () -> verify(recruitBoardRepository).findByAllWithLike(any()),
                 () -> assertThat(allRecruitBoard.getRecruitBoards()).hasSize(100)
         );
     }


### PR DESCRIPTION
다음의 기능을 구현 및 수정했습니다.  

- 모집 게시판 무한 스크롤 조회, 전체 조회, 상세 조회에 좋아요 여부 구현
- 무한 스크롤 동적 쿼리 JPQL -> Querydsl 변경