### PR TITLE
Feat/recruit board 모집게시판, 지원(팀원) 코드 변경

### DIFF
--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantInfoResponse.java
@@ -13,6 +13,7 @@ public class ApplicantInfoResponse {
     private Long userId;
     private Long applicantId;
     private String nickName;
+    private String imgUrl;
     private String email;
     private LocalDateTime createdAt;
 
@@ -21,6 +22,7 @@ public class ApplicantInfoResponse {
                 .userId(response.getUserId())
                 .applicantId(response.getApplicantId())
                 .nickName(response.getNickName())
+                .imgUrl(response.getImgUrl())
                 .email(response.getEmail())
                 .createdAt(response.getCreatedAt())
                 .build();

--- a/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/applicant/ApplicantListResponse.java
@@ -14,6 +14,7 @@ public class ApplicantListResponse {
     private Long userId;
     private Long applicantId;
     private String nickName;
+    private String imgUrl;
     private String email;
     private PositionType positionType;
     private LocalDateTime createdAt;

--- a/server/src/main/java/sideeffect/project/dto/recruit/DetailedBoardPositionResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/DetailedBoardPositionResponse.java
@@ -1,0 +1,40 @@
+package sideeffect.project.dto.recruit;
+
+import lombok.*;
+import sideeffect.project.domain.recruit.BoardPosition;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class DetailedBoardPositionResponse {
+
+    private Long id;
+    private String positionType;
+    private int targetNumber;
+    private int currentNumber;
+    private boolean supported;
+
+    public static DetailedBoardPositionResponse of(BoardPosition boardPosition) {
+        return DetailedBoardPositionResponse.builder()
+                .id(boardPosition.getId())
+                .positionType(boardPosition.getPosition().getPositionType().getValue())
+                .targetNumber(boardPosition.getTargetNumber())
+                .currentNumber(boardPosition.getCurrentNumber())
+                .build();
+    }
+
+    public static List<DetailedBoardPositionResponse> listOf(List<BoardPosition> boardPositions) {
+        return boardPositions.stream()
+                .map(DetailedBoardPositionResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public void updateSupported() {
+        this.supported = true;
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/dto/recruit/DetailedRecruitBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/DetailedRecruitBoardResponse.java
@@ -24,7 +24,7 @@ public class DetailedRecruitBoardResponse {
     private int likeNum;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
-    private List<BoardPositionResponse> positions;
+    private List<DetailedBoardPositionResponse> positions;
     private List<BoardStackResponse> tags;
 
     public static DetailedRecruitBoardResponse ofLike(RecruitBoardAndLikeDto recruitBoardAndLikeDto) {
@@ -40,7 +40,7 @@ public class DetailedRecruitBoardResponse {
                 .like(recruitBoardAndLikeDto.isLike())
                 .likeNum(recruitBoardAndLikeDto.getRecruitBoard().getRecruitLikes().size())
                 .createdAt(recruitBoardAndLikeDto.getRecruitBoard().getCreateAt())
-                .positions(BoardPositionResponse.listOf(recruitBoardAndLikeDto.getRecruitBoard().getBoardPositions()))
+                .positions(DetailedBoardPositionResponse.listOf(recruitBoardAndLikeDto.getRecruitBoard().getBoardPositions()))
                 .tags(BoardStackResponse.listOf(recruitBoardAndLikeDto.getRecruitBoard().getBoardStacks()))
                 .build();
     }

--- a/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/recruit/RecruitBoardResponse.java
@@ -16,6 +16,7 @@ public class RecruitBoardResponse {
 
     private Long id;
     private Long userId;
+    private boolean closed;
     private String title;
     private String projectName;
     private String content;
@@ -71,6 +72,10 @@ public class RecruitBoardResponse {
         return recruitBoards.stream()
                 .map(RecruitBoardResponse::ofLike)
                 .collect(Collectors.toList());
+    }
+
+    public void updateClosed() {
+        this.closed = true;
     }
 
 }

--- a/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/RecruitBoardRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long>, RecruitBoardCustomRepository {
 
-    @Query("SELECT new sideeffect.project.dto.applicant.ApplicantListResponse(a.user.id, a.id, u.nickname, u.email, p.positionType, a.createAt) " +
+    @Query("SELECT new sideeffect.project.dto.applicant.ApplicantListResponse(a.user.id, a.id, u.nickname, u.imgUrl, u.email, p.positionType, a.createAt) " +
             "FROM RecruitBoard rb " +
             "INNER JOIN rb.boardPositions bp " +
             "ON rb.id = :boardId " +

--- a/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
+++ b/server/src/main/java/sideeffect/project/service/RecruitBoardService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import sideeffect.project.common.exception.*;
 import sideeffect.project.common.fileupload.service.RecruitUploadService;
+import sideeffect.project.domain.applicant.Applicant;
 import sideeffect.project.domain.position.Position;
 import sideeffect.project.domain.recruit.BoardPosition;
 import sideeffect.project.domain.recruit.BoardStack;
@@ -47,7 +48,23 @@ public class RecruitBoardService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RECRUIT_BOARD_NOT_FOUND));
         findRecruitBoard.getRecruitBoard().increaseViews();
 
-        return DetailedRecruitBoardResponse.ofLike(findRecruitBoard);
+        DetailedRecruitBoardResponse detailedRecruitBoardResponse = DetailedRecruitBoardResponse.ofLike(findRecruitBoard);
+
+        if(user.getApplicants() != null && !user.getApplicants().isEmpty()) {
+            updateSupportedStatus(detailedRecruitBoardResponse, user.getApplicants());
+        }
+
+        return detailedRecruitBoardResponse;
+    }
+
+    private void updateSupportedStatus(DetailedRecruitBoardResponse detailedRecruitBoardResponse, List<Applicant> applicants) {
+        List<Long> applicantBoardPositionIds = applicants.stream()
+                .map(applicant -> applicant.getBoardPosition().getId())
+                .collect(Collectors.toList());
+
+        detailedRecruitBoardResponse.getPositions().stream()
+                .filter(position -> applicantBoardPositionIds.contains(position.getId()))
+                .forEach(DetailedBoardPositionResponse::updateSupported);
     }
 
     @Transactional(readOnly = true)

--- a/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
+++ b/server/src/test/java/sideeffect/project/controller/RecruitBoardControllerTest.java
@@ -76,7 +76,7 @@ class RecruitBoardControllerTest {
                 .title("모집 게시글 제목")
                 .projectName("프로젝트명1")
                 .content("모집 게시글 내용")
-                .positions(List.of(new BoardPositionResponse(1L, PositionType.BACKEND.getValue(), 3, 0)))
+                .positions(List.of(new DetailedBoardPositionResponse(1L, PositionType.BACKEND.getValue(), 3, 0, false)))
                 .tags(List.of(new BoardStackResponse(StackType.SPRING.getValue(), "url")))
                 .build();
 


### PR DESCRIPTION
다음의 기능을 구현 및 수정했습니다.  

- 모집 게시판 스크롤 조회에 마감 여부 추가
- 모집 게시판 상세 조회에 지원자의 지원 여부 추가
- 지원(팀원) 목록에 imgUrl 추가