### PR TITLE
Feat/token 로그아웃 기능 구현과 TokenProvider 수정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/server/src/main/java/sideeffect/project/ProjectApplication.java
+++ b/server/src/main/java/sideeffect/project/ProjectApplication.java
@@ -2,10 +2,13 @@ package sideeffect.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import sideeffect.project.config.security.AuthProperties;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy(proxyTargetClass = true)
+@EnableConfigurationProperties(AuthProperties.class)
 public class ProjectApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/sideeffect/project/config/security/AuthProperties.java
+++ b/server/src/main/java/sideeffect/project/config/security/AuthProperties.java
@@ -1,0 +1,29 @@
+package sideeffect.project.config.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+public class AuthProperties {
+
+    private String secret;
+    private Long expired;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public Long getExpired() {
+        return expired;
+    }
+
+    public void setExpired(Long expired) {
+        this.expired = expired;
+    }
+
+}

--- a/server/src/main/java/sideeffect/project/controller/RefreshTokenController.java
+++ b/server/src/main/java/sideeffect/project/controller/RefreshTokenController.java
@@ -3,6 +3,8 @@ package sideeffect.project.controller;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
 import sideeffect.project.common.exception.AuthException;
 import sideeffect.project.common.exception.ErrorCode;
@@ -27,7 +29,25 @@ public class RefreshTokenController {
         response.addHeader("Authorization", accessToken);
     }
 
-    private String getToken(String refreshToken) {
-        return refreshToken.substring(6);
+    @DeleteMapping("/logout")
+    public void logout(@CookieValue(value = "token", required = false) String refreshToken, HttpServletResponse response) {
+
+        if (refreshToken == null) {
+            throw new AuthException(ErrorCode.REFRESH_TOKEN_NOT_REQUEST);
+        }
+
+        refreshTokenProvider.deleteToken(refreshToken);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, createBlankCookie().toString());
+    }
+
+    private ResponseCookie createBlankCookie() {
+        return ResponseCookie.from("token", null)
+            .sameSite("None")
+            .secure(true)
+            .path("/api/token/")
+            .httpOnly(true)
+            .maxAge(0)
+            .build();
     }
 }

--- a/server/src/main/java/sideeffect/project/dto/user/RefreshTokenResponse.java
+++ b/server/src/main/java/sideeffect/project/dto/user/RefreshTokenResponse.java
@@ -14,11 +14,9 @@ import sideeffect.project.domain.token.RefreshToken;
 public class RefreshTokenResponse {
 
     private Long userId;
-    private String refreshToken;
 
     public static RefreshTokenResponse of(RefreshToken refreshToken) {
         return RefreshTokenResponse.builder()
-            .refreshToken("token=" + refreshToken.getRefreshToken())
             .userId(refreshToken.getUserId())
             .build();
     }

--- a/server/src/main/java/sideeffect/project/security/LoginSuccessHandler.java
+++ b/server/src/main/java/sideeffect/project/security/LoginSuccessHandler.java
@@ -26,17 +26,23 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         RefreshToken refreshToken = refreshTokenProvider.createRefreshToken(authentication);
         String accessToken = refreshTokenProvider.issueAccessToken(refreshToken.getRefreshToken());
+
+        addHeaders(response, refreshToken.getRefreshToken(), accessToken);
+
+        response.getWriter().write(new ObjectMapper().writeValueAsString(RefreshTokenResponse.of(refreshToken)));
+    }
+
+    private void addHeaders(HttpServletResponse response, String refreshToken, String accessToken) {
         response.addHeader("Authorization", accessToken);
         response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(refreshToken.getRefreshToken()).toString());
-        response.getWriter().write(new ObjectMapper().writeValueAsString(RefreshTokenResponse.of(refreshToken)));
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(refreshToken).toString());
     }
 
     private ResponseCookie createCookie(String refreshToken) {
         return ResponseCookie.from("token", refreshToken)
             .sameSite("None")
             .secure(true)
-            .path("/api/token/at-issue")
+            .path("/api/token/")
             .httpOnly(true)
             .build();
     }

--- a/server/src/main/java/sideeffect/project/security/RefreshTokenProvider.java
+++ b/server/src/main/java/sideeffect/project/security/RefreshTokenProvider.java
@@ -53,6 +53,10 @@ public class RefreshTokenProvider {
         return refreshTokenRepository.save(refreshToken);
     }
 
+    public void deleteToken(String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
+    }
+
     private Date createExpiration() {
         return new Date(System.currentTimeMillis() + EXPIRATION_TIME);
     }

--- a/server/src/main/java/sideeffect/project/security/RefreshTokenProvider.java
+++ b/server/src/main/java/sideeffect/project/security/RefreshTokenProvider.java
@@ -4,12 +4,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sideeffect.project.common.exception.EntityNotFoundException;
 import sideeffect.project.common.exception.ErrorCode;
+import sideeffect.project.config.security.AuthProperties;
 import sideeffect.project.domain.token.RefreshToken;
 import sideeffect.project.domain.user.User;
 import sideeffect.project.domain.user.UserRoleType;
@@ -26,8 +26,8 @@ import java.util.UUID;
 public class RefreshTokenProvider {
 
     private static final int EXPIRATION_TIME = 1000 * 60 * 30;
-    @Value("${jwt.secret}")
-    private String secretKey;
+    
+    private final AuthProperties authProperties;
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
@@ -43,7 +43,7 @@ public class RefreshTokenProvider {
                 .claim("auth", UserRoleType.ROLE_USER)
                 .claim("providerType", user.getProviderType())
                 .setExpiration(createExpiration())
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(SignatureAlgorithm.HS256, authProperties.getSecret())
                 .compact();
     }
 

--- a/server/src/main/java/sideeffect/project/security/UserDetailsServiceImpl.java
+++ b/server/src/main/java/sideeffect/project/security/UserDetailsServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sideeffect.project.common.exception.EntityNotFoundException;
+import sideeffect.project.common.exception.ErrorCode;
 import sideeffect.project.common.exception.JoinException;
 import sideeffect.project.domain.user.ProviderType;
 import sideeffect.project.domain.user.User;
@@ -31,6 +33,14 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     public UserDetails loadUserByUsernameAndProviderType(String email, ProviderType providerType) throws UsernameNotFoundException {
         log.info("UserDetailsServiceImpl(provider) 진입");
         User user = userRepository.findByEmailAndProvider(email, providerType).orElseThrow(() -> new JoinException(email));
+
+        return UserDetailsImpl.of(user);
+    }
+
+    @Transactional
+    public UserDetails loadUserByUserId(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         return UserDetailsImpl.of(user);
     }

--- a/server/src/test/java/sideeffect/project/security/JwtTokenProviderTest.java
+++ b/server/src/test/java/sideeffect/project/security/JwtTokenProviderTest.java
@@ -1,0 +1,138 @@
+package sideeffect.project.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import sideeffect.project.common.exception.AuthException;
+import sideeffect.project.common.exception.ErrorCode;
+import sideeffect.project.domain.user.ProviderType;
+import sideeffect.project.domain.user.User;
+import sideeffect.project.domain.user.UserRoleType;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider tokenProvider;
+
+    @Mock
+    private UserDetailsServiceImpl userDetailsService;
+
+    private User user;
+    private String secretKey;
+
+    @BeforeEach
+    void setUp() {
+        tokenProvider = new JwtTokenProvider(userDetailsService);
+
+        secretKey = UUID.randomUUID().toString();
+
+        ReflectionTestUtils.setField(tokenProvider, "secretKey", secretKey);
+
+        user = User.builder()
+            .email("test@naver.com")
+            .password("123455")
+            .providerType(ProviderType.DEFAULT)
+            .userRoleType(UserRoleType.ROLE_USER)
+            .build();
+    }
+
+    @DisplayName("엑세스 토큰을 발급한다.")
+    @Test
+    void createAccessToken() {
+        when(userDetailsService.loadUserByUserId(any())).thenReturn(UserDetailsImpl.of(user));
+
+        String accessToken = tokenProvider.createAccessToken(user.getId());
+
+        System.out.println("accessToken = " + accessToken);
+        assertAll(
+            () -> assertThat(accessToken).isNotNull(),
+            () -> verify(userDetailsService).loadUserByUserId(any())
+        );
+    }
+
+    @DisplayName("엑세스 토큰으로 인증 객체를 추출한다.")
+    @Test
+    void getAuthentication() {
+        Long time = 1000 * 60L;
+        String token = createToken(time);
+        when(userDetailsService.loadUserByUsernameAndProviderType(any(), any()))
+            .thenReturn(UserDetailsImpl.of(user));
+
+        tokenProvider.getAuthentication(token);
+
+        verify(userDetailsService).loadUserByUsernameAndProviderType(any(), any());
+    }
+
+    @DisplayName("만료된 토큰을 받으면 예외가 발생한다.")
+    @Test
+    void inputExpiredAccessToken() {
+        String token = createToken(0L);
+
+        assertThatThrownBy(() -> tokenProvider.validateAccessToken(token))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(ErrorCode.ACCESS_TOKEN_EXPIRED.getMessage());
+    }
+
+    @DisplayName("토큰이 null이면 예외가 발생된다.")
+    @Test
+    void inputNullAccessToken() {
+        String token = null;
+
+        assertThatThrownBy(() -> tokenProvider.validateAccessToken(token))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(ErrorCode.ACCESS_TOKEN_ILLEGAL_STATE.getMessage());
+    }
+
+    @DisplayName("토큰이 잘못된 형식이면 예외가 발생한다.")
+    @Test
+    void inputMalformedAccessToken() {
+        String token = "hello";
+
+        assertThatThrownBy(() -> tokenProvider.validateAccessToken(token))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(ErrorCode.ACCESS_TOKEN_MALFORMED.getMessage());
+    }
+
+    @DisplayName("다른 키로 암호화된 토큰이면 예외가 발생한다.")
+    @Test
+    void inputOtherSignatureAccessToken() {
+        String otherKey = "1234";
+        String token = Jwts.builder()
+            .setSubject(user.getEmail())
+            .claim("auth", user.getUserRoleType())
+            .claim("providerType", user.getProviderType())
+            .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60))
+            .signWith(SignatureAlgorithm.HS256, otherKey)
+            .compact();
+
+        assertThatThrownBy(() -> tokenProvider.validateAccessToken(token))
+            .isInstanceOf(AuthException.class)
+            .hasMessage(ErrorCode.ACCESS_TOKEN_SIGNATURE_FAILED.getMessage());
+    }
+
+
+    private String createToken(Long time) {
+        return Jwts.builder()
+            .setSubject(user.getEmail())
+            .claim("auth", user.getUserRoleType())
+            .claim("providerType", user.getProviderType())
+            .setExpiration(new Date(System.currentTimeMillis() + time))
+            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .compact();
+    }
+}

--- a/server/src/test/java/sideeffect/project/security/RefreshTokenProviderTest.java
+++ b/server/src/test/java/sideeffect/project/security/RefreshTokenProviderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,6 +41,7 @@ class RefreshTokenProviderTest {
         ReflectionTestUtils.setField(refreshTokenProvider, "secretKey", "testKey");
     }
 
+    @DisplayName("엑세스 토큰을 재발급 한다.")
     @Test
     void issueAccessToken() {
         String token = UUID.randomUUID().toString();
@@ -56,12 +58,23 @@ class RefreshTokenProviderTest {
         );
     }
 
+    @DisplayName("refresh token을 발급한다.")
     @Test
     void createRefreshToken() {
         Authentication authentication = createAuthentication();
         refreshTokenProvider.createRefreshToken(authentication);
 
         verify(refreshTokenRepository).save(any());
+    }
+
+    @DisplayName("refresh token을 삭제한다.")
+    @Test
+    void deleteToken() {
+        String token = UUID.randomUUID().toString();
+
+        refreshTokenProvider.deleteToken(token);
+
+        verify(refreshTokenProvider).deleteToken(any());
     }
 
     private Authentication createAuthentication() {


### PR DESCRIPTION
다음의 기능을 구현했습니다.
- 로그아웃 기능 구현 (redis에 저장된 토큰 삭제 + 수명이 0인 쿠키 전달)
- 프로퍼티스 클래스를 구현해서 TokenProvider에 적용
- AccessTokenProvider에서 만  accessToken을 만들도록 변경
- UserDetailService에 id로 유저를 찾는 기능 추가