### PR TITLE
refactor: 지원 취소 API BoardPositionId로 취소하도록 변경

### DIFF
--- a/server/src/main/java/sideeffect/project/controller/ApplicantController.java
+++ b/server/src/main/java/sideeffect/project/controller/ApplicantController.java
@@ -53,8 +53,8 @@ public class ApplicantController {
 
     @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
     @DeleteMapping("/{id}")
-    public void cancelApplicant(@LoginUser User user, @PathVariable("id") Long applicantId) {
-        applicantService.cancelApplicant(user.getId(), applicantId);
+    public void cancelApplicant(@LoginUser User user, @PathVariable("id") Long boardPositionId) {
+        applicantService.cancelApplicant(user.getId(), boardPositionId);
     }
 
 }

--- a/server/src/main/java/sideeffect/project/repository/ApplicantRepository.java
+++ b/server/src/main/java/sideeffect/project/repository/ApplicantRepository.java
@@ -1,8 +1,17 @@
 package sideeffect.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sideeffect.project.domain.applicant.Applicant;
 
+import java.util.Optional;
+
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+
+    @Query("SELECT a " +
+            "FROM Applicant a " +
+            "WHERE a.boardPosition.id = :boardPositionId AND a.user.id = :userId")
+    Optional<Applicant> isUserApplicantForBoardPosition(@Param("userId") Long userId, @Param("boardPositionId") Long boardPositionId);
 
 }

--- a/server/src/main/java/sideeffect/project/service/ApplicantService.java
+++ b/server/src/main/java/sideeffect/project/service/ApplicantService.java
@@ -126,8 +126,8 @@ public class ApplicantService {
     }
 
     @Transactional
-    public void cancelApplicant(Long userId, Long applicantId) {
-        Applicant findApplicant = applicantRepository.findById(applicantId)
+    public void cancelApplicant(Long userId, Long boardPositionId) {
+        Applicant findApplicant = applicantRepository.isUserApplicantForBoardPosition(userId, boardPositionId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLICANT_NOT_FOUND));
 
         validateCancelOwner(findApplicant, userId);


### PR DESCRIPTION
다음의 기능을 수정했습니다.  

- 지원 취소 API BoardPositionId로 삭제할 수 있도록 수정